### PR TITLE
Import ExecutionContext library with isolated async-local context scopes

### DIFF
--- a/src/MongODM.AspNetCore/DbDependencies.cs
+++ b/src/MongODM.AspNetCore/DbDependencies.cs
@@ -12,9 +12,9 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.ExecContext;
 using Etherna.MongoDB.Bson.Serialization;
 using Etherna.MongODM.Core;
+using Etherna.MongODM.Core.ExecContext;
 using Etherna.MongODM.Core.Options;
 using Etherna.MongODM.Core.ProxyModels;
 using Etherna.MongODM.Core.Repositories;

--- a/src/MongODM.AspNetCore/ExecContext/HttpContextExecutionContext.cs
+++ b/src/MongODM.AspNetCore/ExecContext/HttpContextExecutionContext.cs
@@ -1,30 +1,27 @@
-﻿// Copyright 2020-present Etherna SA
+// Copyright 2020-present Etherna SA
 // This file is part of MongODM.
-// 
+//
 // MongODM is free software: you can redistribute it and/or modify it under the terms of the
 // GNU Lesser General Public License as published by the Free Software Foundation,
 // either version 3 of the License, or (at your option) any later version.
-// 
+//
 // MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 // See the GNU Lesser General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.MongoDB.Bson.Serialization;
 using Etherna.MongODM.Core.ExecContext;
+using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
 
-namespace Etherna.MongODM.Core.Utility
+namespace Etherna.MongODM.AspNetCore.ExecContext
 {
-    public class SerializationContextAccessor(IExecutionContext executionContext)
-        : ISerializationContextAccessor
+    public class HttpContextExecutionContext(IHttpContextAccessor httpContextAccessor)
+        : IExecutionContext
     {
-        // Method.
-        public IBsonSerializerRegistry? TryGetCurrentBsonSerializerRegistry()
-        {
-            var dbContext = DbExecutionContextHandler.TryGetCurrentDbContext(executionContext);
-            return dbContext?.SerializerRegistry;
-        }
+        // Properties.
+        public IDictionary<object, object?>? Items => httpContextAccessor.HttpContext?.Items;
     }
 }

--- a/src/MongODM.AspNetCore/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/MongODM.AspNetCore/Extensions/ApplicationBuilderExtensions.cs
@@ -12,8 +12,8 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.ExecContext.AsyncLocal;
 using Etherna.MongODM.Core;
+using Etherna.MongODM.Core.ExecContext.AsyncLocal;
 using Etherna.MongODM.Core.Options;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/MongODM.AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MongODM.AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -12,14 +12,15 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.ExecContext;
-using Etherna.ExecContext.AspNetCore;
 using Etherna.MongoDB.Bson;
 using Etherna.MongoDB.Bson.Serialization;
 using Etherna.MongoDB.Bson.Serialization.Conventions;
 using Etherna.MongODM.AspNetCore;
+using Etherna.MongODM.AspNetCore.ExecContext;
 using Etherna.MongODM.Core;
 using Etherna.MongODM.Core.Conventions;
+using Etherna.MongODM.Core.ExecContext;
+using Etherna.MongODM.Core.ExecContext.AsyncLocal;
 using Etherna.MongODM.Core.Options;
 using Etherna.MongODM.Core.ProxyModels;
 using Etherna.MongODM.Core.Repositories;
@@ -27,6 +28,7 @@ using Etherna.MongODM.Core.Serialization.Mapping;
 using Etherna.MongODM.Core.Serialization.Modifiers;
 using Etherna.MongODM.Core.Tasks;
 using Etherna.MongODM.Core.Utility;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
@@ -35,6 +37,21 @@ namespace Etherna.MongODM
 {
     public static class ServiceCollectionExtensions
     {
+        public static IServiceCollection AddExecutionContext(
+            this IServiceCollection services)
+        {
+            services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+
+            services.TryAddSingleton<IExecutionContext>(serviceProvider =>
+               new ExecutionContextSelector( //default
+               [
+                   new HttpContextExecutionContext(serviceProvider.GetRequiredService<IHttpContextAccessor>()),
+                   AsyncLocalContext.Instance
+               ]));
+
+            return services;
+        }
+
         public static IMongODMConfiguration AddMongODM<TTaskRunner>(
             this IServiceCollection services,
             Action<MongODMOptions>? configureOptions = null)

--- a/src/MongODM.AspNetCore/MongODM.AspNetCore.csproj
+++ b/src/MongODM.AspNetCore/MongODM.AspNetCore.csproj
@@ -30,7 +30,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ExecutionContext.AspNetCore" Version="1.3.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="6.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MongODM.Core/Conventions/HierarchicalProxyTolerantDiscriminatorConvention.cs
+++ b/src/MongODM.Core/Conventions/HierarchicalProxyTolerantDiscriminatorConvention.cs
@@ -12,12 +12,12 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.ExecContext;
 using Etherna.MongoDB.Bson;
 using Etherna.MongoDB.Bson.IO;
 using Etherna.MongoDB.Bson.Serialization;
 using Etherna.MongoDB.Bson.Serialization.Conventions;
 using Etherna.MongoDB.Bson.Serialization.Serializers;
+using Etherna.MongODM.Core.ExecContext;
 using Etherna.MongODM.Core.Utility;
 using System;
 using System.Collections.Generic;

--- a/src/MongODM.Core/DbContext.cs
+++ b/src/MongODM.Core/DbContext.cs
@@ -12,13 +12,13 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.ExecContext;
 using Etherna.MongoDB.Bson.Serialization;
 using Etherna.MongoDB.Driver;
 using Etherna.MongoDB.Driver.Linq;
 using Etherna.MongODM.Core.Domain.ModelMaps;
 using Etherna.MongODM.Core.Domain.Models;
 using Etherna.MongODM.Core.Exceptions;
+using Etherna.MongODM.Core.ExecContext;
 using Etherna.MongODM.Core.Extensions;
 using Etherna.MongODM.Core.Migration;
 using Etherna.MongODM.Core.Options;

--- a/src/MongODM.Core/ExecContext/AsyncLocal/AsyncLocalContext.cs
+++ b/src/MongODM.Core/ExecContext/AsyncLocal/AsyncLocalContext.cs
@@ -1,0 +1,60 @@
+// Copyright 2020-present Etherna SA
+// This file is part of MongODM.
+//
+// MongODM is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with MongODM.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Etherna.MongODM.Core.ExecContext.AsyncLocal
+{
+    /// <summary>
+    ///     Async local context implementation. This can be used as singleton or with multiple instances.
+    ///     The <see cref="AsyncLocal{T}"/> container permits to have an Item instance inside this
+    ///     method calling tree.
+    /// </summary>
+    /// <remarks>
+    ///     Before try to use an async local context, call the method <see cref="InitAsyncLocalContext"/>
+    ///     for initialize the <see cref="AsyncLocal{T}"/> container, and receive a context handler.
+    ///     Each initialization creates a new isolated context, also when another context is already
+    ///     present, for example inherited from an ancestor async flow. After have used, dispose the
+    ///     handler for restore the previous context.
+    /// </remarks>
+    public class AsyncLocalContext : IAsyncLocalContext, IHandledAsyncLocalContext
+    {
+        // Fields.
+        private static readonly AsyncLocal<IDictionary<object, object?>?> asyncLocalContext = new();
+
+        // Properties.
+        public IDictionary<object, object?>? Items => asyncLocalContext.Value;
+
+        // Static properties.
+        public static IAsyncLocalContext Instance { get; } = new AsyncLocalContext();
+
+        // Methods.
+        public IAsyncLocalContextHandler InitAsyncLocalContext()
+        {
+            var parentItems = asyncLocalContext.Value;
+            asyncLocalContext.Value = new Dictionary<object, object?>();
+
+            return new AsyncLocalContextHandler(this, parentItems);
+        }
+
+        public void OnDisposed(IAsyncLocalContextHandler handler)
+        {
+            ArgumentNullException.ThrowIfNull(handler);
+
+            asyncLocalContext.Value = ((AsyncLocalContextHandler)handler).ParentItems;
+        }
+    }
+}

--- a/src/MongODM.Core/ExecContext/AsyncLocal/AsyncLocalContextHandler.cs
+++ b/src/MongODM.Core/ExecContext/AsyncLocal/AsyncLocalContextHandler.cs
@@ -1,0 +1,51 @@
+// Copyright 2020-present Etherna SA
+// This file is part of MongODM.
+//
+// MongODM is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with MongODM.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+
+namespace Etherna.MongODM.Core.ExecContext.AsyncLocal
+{
+    /// <summary>
+    ///     The handler for an <see cref="AsyncLocalContext"/> initialization.
+    ///     Dispose this for restore the previous context.
+    /// </summary>
+    public sealed class AsyncLocalContextHandler : IAsyncLocalContextHandler
+    {
+        // Fields.
+        private bool disposed;
+
+        // Constructors.
+        internal AsyncLocalContextHandler(
+            IHandledAsyncLocalContext handledContext,
+            IDictionary<object, object?>? parentItems)
+        {
+            HandledContext = handledContext;
+            ParentItems = parentItems;
+        }
+
+        // Internal properties.
+        internal IHandledAsyncLocalContext HandledContext { get; }
+        internal IDictionary<object, object?>? ParentItems { get; }
+
+        // Methods.
+        public void Dispose()
+        {
+            if (disposed)
+                return;
+
+            HandledContext.OnDisposed(this);
+            disposed = true;
+        }
+    }
+}

--- a/src/MongODM.Core/ExecContext/AsyncLocal/IAsyncLocalContext.cs
+++ b/src/MongODM.Core/ExecContext/AsyncLocal/IAsyncLocalContext.cs
@@ -1,30 +1,30 @@
-﻿// Copyright 2020-present Etherna SA
+// Copyright 2020-present Etherna SA
 // This file is part of MongODM.
-// 
+//
 // MongODM is free software: you can redistribute it and/or modify it under the terms of the
 // GNU Lesser General Public License as published by the Free Software Foundation,
 // either version 3 of the License, or (at your option) any later version.
-// 
+//
 // MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 // See the GNU Lesser General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.MongoDB.Bson.Serialization;
-using Etherna.MongODM.Core.ExecContext;
-
-namespace Etherna.MongODM.Core.Utility
+namespace Etherna.MongODM.Core.ExecContext.AsyncLocal
 {
-    public class SerializationContextAccessor(IExecutionContext executionContext)
-        : ISerializationContextAccessor
+    /// <summary>
+    ///     The <see cref="AsyncLocalContext"/> interface.
+    ///     Permits to create an async local context living with the method calling tree.
+    /// </summary>
+    public interface IAsyncLocalContext : IExecutionContext
     {
-        // Method.
-        public IBsonSerializerRegistry? TryGetCurrentBsonSerializerRegistry()
-        {
-            var dbContext = DbExecutionContextHandler.TryGetCurrentDbContext(executionContext);
-            return dbContext?.SerializerRegistry;
-        }
+        /// <summary>
+        /// Initialize a new isolated async local context, replacing any current one.
+        /// Disposing the returned handler restores the previous context.
+        /// </summary>
+        /// <returns>The new context handler</returns>
+        IAsyncLocalContextHandler InitAsyncLocalContext();
     }
 }

--- a/src/MongODM.Core/ExecContext/AsyncLocal/IAsyncLocalContextHandler.cs
+++ b/src/MongODM.Core/ExecContext/AsyncLocal/IAsyncLocalContextHandler.cs
@@ -1,30 +1,24 @@
-﻿// Copyright 2020-present Etherna SA
+// Copyright 2020-present Etherna SA
 // This file is part of MongODM.
-// 
+//
 // MongODM is free software: you can redistribute it and/or modify it under the terms of the
 // GNU Lesser General Public License as published by the Free Software Foundation,
 // either version 3 of the License, or (at your option) any later version.
-// 
+//
 // MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 // See the GNU Lesser General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.MongoDB.Bson.Serialization;
-using Etherna.MongODM.Core.ExecContext;
+using System;
 
-namespace Etherna.MongODM.Core.Utility
+namespace Etherna.MongODM.Core.ExecContext.AsyncLocal
 {
-    public class SerializationContextAccessor(IExecutionContext executionContext)
-        : ISerializationContextAccessor
-    {
-        // Method.
-        public IBsonSerializerRegistry? TryGetCurrentBsonSerializerRegistry()
-        {
-            var dbContext = DbExecutionContextHandler.TryGetCurrentDbContext(executionContext);
-            return dbContext?.SerializerRegistry;
-        }
-    }
+    /// <summary>
+    /// A disposable interface for <see cref="AsyncLocalContextHandler"/>
+    /// </summary>
+    public interface IAsyncLocalContextHandler : IDisposable
+    { }
 }

--- a/src/MongODM.Core/ExecContext/AsyncLocal/IHandledAsyncLocalContext.cs
+++ b/src/MongODM.Core/ExecContext/AsyncLocal/IHandledAsyncLocalContext.cs
@@ -1,30 +1,25 @@
-﻿// Copyright 2020-present Etherna SA
+// Copyright 2020-present Etherna SA
 // This file is part of MongODM.
-// 
+//
 // MongODM is free software: you can redistribute it and/or modify it under the terms of the
 // GNU Lesser General Public License as published by the Free Software Foundation,
 // either version 3 of the License, or (at your option) any later version.
-// 
+//
 // MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 // See the GNU Lesser General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.MongoDB.Bson.Serialization;
-using Etherna.MongODM.Core.ExecContext;
-
-namespace Etherna.MongODM.Core.Utility
+namespace Etherna.MongODM.Core.ExecContext.AsyncLocal
 {
-    public class SerializationContextAccessor(IExecutionContext executionContext)
-        : ISerializationContextAccessor
+    /// <summary>
+    ///     Interface used by <see cref="AsyncLocalContextHandler"/> for comunicate with its
+    ///     creator <see cref="AsyncLocalContext"/>.
+    /// </summary>
+    internal interface IHandledAsyncLocalContext
     {
-        // Method.
-        public IBsonSerializerRegistry? TryGetCurrentBsonSerializerRegistry()
-        {
-            var dbContext = DbExecutionContextHandler.TryGetCurrentDbContext(executionContext);
-            return dbContext?.SerializerRegistry;
-        }
+        void OnDisposed(IAsyncLocalContextHandler handler);
     }
 }

--- a/src/MongODM.Core/ExecContext/Exceptions/ExecutionContextNotFoundException.cs
+++ b/src/MongODM.Core/ExecContext/Exceptions/ExecutionContextNotFoundException.cs
@@ -1,30 +1,30 @@
-﻿// Copyright 2020-present Etherna SA
+// Copyright 2020-present Etherna SA
 // This file is part of MongODM.
-// 
+//
 // MongODM is free software: you can redistribute it and/or modify it under the terms of the
 // GNU Lesser General Public License as published by the Free Software Foundation,
 // either version 3 of the License, or (at your option) any later version.
-// 
+//
 // MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 // See the GNU Lesser General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.MongoDB.Bson.Serialization;
-using Etherna.MongODM.Core.ExecContext;
+using System;
 
-namespace Etherna.MongODM.Core.Utility
+namespace Etherna.MongODM.Core.ExecContext.Exceptions
 {
-    public class SerializationContextAccessor(IExecutionContext executionContext)
-        : ISerializationContextAccessor
+    public class ExecutionContextNotFoundException : Exception
     {
-        // Method.
-        public IBsonSerializerRegistry? TryGetCurrentBsonSerializerRegistry()
-        {
-            var dbContext = DbExecutionContextHandler.TryGetCurrentDbContext(executionContext);
-            return dbContext?.SerializerRegistry;
-        }
+        public ExecutionContextNotFoundException(string message) : base(message)
+        { }
+
+        public ExecutionContextNotFoundException(string message, Exception innerException) : base(message, innerException)
+        { }
+
+        public ExecutionContextNotFoundException()
+        { }
     }
 }

--- a/src/MongODM.Core/ExecContext/ExecutionContextSelector.cs
+++ b/src/MongODM.Core/ExecContext/ExecutionContextSelector.cs
@@ -1,0 +1,50 @@
+// Copyright 2020-present Etherna SA
+// This file is part of MongODM.
+//
+// MongODM is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with MongODM.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+
+namespace Etherna.MongODM.Core.ExecContext
+{
+    /// <summary>
+    ///     A multi context selector that take different contexts, and select the first available.
+    /// </summary>
+    /// <remarks>
+    ///     This class is intended to have the same lifetime of its consumer. For example, in case
+    ///     of using with a DbContext, the same DbContext instance will use the same ContextSelector
+    ///     instance. This mean that if a DbContext is running over different execution contexts,
+    ///     every <see cref="Items"/> invoke on same context needs to return the same dictionary.
+    ///     The simplest way to perform this, is to return the first not null available dictionary
+    ///     on subscribed contexts.
+    /// </remarks>
+    public class ExecutionContextSelector(IEnumerable<IExecutionContext> contexts)
+        : IExecutionContext
+    {
+        // Fields.
+        private readonly IEnumerable<IExecutionContext> contexts =
+            contexts ?? throw new ArgumentNullException(nameof(contexts));
+
+        // Properties.
+        public IDictionary<object, object?>? Items
+        {
+            get
+            {
+                foreach (var context in contexts)
+                    if (context.Items != null)
+                        return context.Items;
+                return null;
+            }
+        }
+    }
+}

--- a/src/MongODM.Core/ExecContext/IExecutionContext.cs
+++ b/src/MongODM.Core/ExecContext/IExecutionContext.cs
@@ -1,30 +1,30 @@
-﻿// Copyright 2020-present Etherna SA
+// Copyright 2020-present Etherna SA
 // This file is part of MongODM.
-// 
+//
 // MongODM is free software: you can redistribute it and/or modify it under the terms of the
 // GNU Lesser General Public License as published by the Free Software Foundation,
 // either version 3 of the License, or (at your option) any later version.
-// 
+//
 // MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 // See the GNU Lesser General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.MongoDB.Bson.Serialization;
-using Etherna.MongODM.Core.ExecContext;
+using System.Collections.Generic;
 
-namespace Etherna.MongODM.Core.Utility
+namespace Etherna.MongODM.Core.ExecContext
 {
-    public class SerializationContextAccessor(IExecutionContext executionContext)
-        : ISerializationContextAccessor
+    /// <summary>
+    /// Represents an execution context, where information can be put and retrieve alongside
+    /// the process with a key-value dictionary.
+    /// </summary>
+    public interface IExecutionContext
     {
-        // Method.
-        public IBsonSerializerRegistry? TryGetCurrentBsonSerializerRegistry()
-        {
-            var dbContext = DbExecutionContextHandler.TryGetCurrentDbContext(executionContext);
-            return dbContext?.SerializerRegistry;
-        }
+        /// <summary>
+        /// The context dictionary.
+        /// </summary>
+        IDictionary<object, object?>? Items { get; }
     }
 }

--- a/src/MongODM.Core/IDbContext.cs
+++ b/src/MongODM.Core/IDbContext.cs
@@ -12,10 +12,10 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.ExecContext;
 using Etherna.MongoDB.Bson.Serialization;
 using Etherna.MongoDB.Driver;
 using Etherna.MongODM.Core.Domain.Models;
+using Etherna.MongODM.Core.ExecContext;
 using Etherna.MongODM.Core.Migration;
 using Etherna.MongODM.Core.Options;
 using Etherna.MongODM.Core.ProxyModels;

--- a/src/MongODM.Core/IDbDependencies.cs
+++ b/src/MongODM.Core/IDbDependencies.cs
@@ -12,8 +12,8 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.ExecContext;
 using Etherna.MongoDB.Bson.Serialization;
+using Etherna.MongODM.Core.ExecContext;
 using Etherna.MongODM.Core.ProxyModels;
 using Etherna.MongODM.Core.Repositories;
 using Etherna.MongODM.Core.Serialization.Mapping;

--- a/src/MongODM.Core/MongODM.Core.csproj
+++ b/src/MongODM.Core/MongODM.Core.csproj
@@ -28,7 +28,6 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="5.2.1" />
     <PackageReference Include="Etherna.MongoDB.Driver" Version="3.8.1" />
-    <PackageReference Include="ExecutionContext" Version="1.3.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="6.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MongODM.Core/Serialization/Modifiers/CacheSerializerModifier.cs
+++ b/src/MongODM.Core/Serialization/Modifiers/CacheSerializerModifier.cs
@@ -12,8 +12,8 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.ExecContext;
-using Etherna.ExecContext.Exceptions;
+using Etherna.MongODM.Core.ExecContext;
+using Etherna.MongODM.Core.ExecContext.Exceptions;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/MongODM.Core/Serialization/Modifiers/ReferenceSerializerModifier.cs
+++ b/src/MongODM.Core/Serialization/Modifiers/ReferenceSerializerModifier.cs
@@ -12,8 +12,8 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.ExecContext;
-using Etherna.ExecContext.Exceptions;
+using Etherna.MongODM.Core.ExecContext;
+using Etherna.MongODM.Core.ExecContext.Exceptions;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/MongODM.Core/Serialization/Modifiers/SerializerModifierAccessor.cs
+++ b/src/MongODM.Core/Serialization/Modifiers/SerializerModifierAccessor.cs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.ExecContext;
+using Etherna.MongODM.Core.ExecContext;
 using System;
 
 namespace Etherna.MongODM.Core.Serialization.Modifiers

--- a/src/MongODM.Core/Utility/DbCache.cs
+++ b/src/MongODM.Core/Utility/DbCache.cs
@@ -12,8 +12,8 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.ExecContext;
 using Etherna.MongODM.Core.Domain.Models;
+using Etherna.MongODM.Core.ExecContext;
 using Etherna.MongODM.Core.Extensions;
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/MongODM.Core/Utility/DbExecutionContextHandler.cs
+++ b/src/MongODM.Core/Utility/DbExecutionContextHandler.cs
@@ -12,8 +12,8 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.ExecContext;
-using Etherna.ExecContext.AsyncLocal;
+using Etherna.MongODM.Core.ExecContext;
+using Etherna.MongODM.Core.ExecContext.AsyncLocal;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/MongODM.Core/Utility/ExclusiveAccessHandler.cs
+++ b/src/MongODM.Core/Utility/ExclusiveAccessHandler.cs
@@ -12,8 +12,8 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.ExecContext;
-using Etherna.ExecContext.Exceptions;
+using Etherna.MongODM.Core.ExecContext;
+using Etherna.MongODM.Core.ExecContext.Exceptions;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/MongODM.Hangfire/Extensions/HangfireGlobalConfigExtension.cs
+++ b/src/MongODM.Hangfire/Extensions/HangfireGlobalConfigExtension.cs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.ExecContext.AsyncLocal;
+using Etherna.MongODM.Core.ExecContext.AsyncLocal;
 using Etherna.MongODM.HF.Filters;
 
 namespace Hangfire

--- a/src/MongODM.Hangfire/Filters/AsyncLocalContextHangfireFilter.cs
+++ b/src/MongODM.Hangfire/Filters/AsyncLocalContextHangfireFilter.cs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.ExecContext.AsyncLocal;
+using Etherna.MongODM.Core.ExecContext.AsyncLocal;
 using Hangfire.Server;
 using System;
 using System.Collections.Generic;

--- a/test/MongODM.Core.Tests/DbContextTest.cs
+++ b/test/MongODM.Core.Tests/DbContextTest.cs
@@ -12,10 +12,10 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.ExecContext.AsyncLocal;
 using Etherna.MongoDB.Bson.Serialization;
 using Etherna.MongoDB.Driver;
 using Etherna.MongODM.Core.Domain.Models;
+using Etherna.MongODM.Core.ExecContext.AsyncLocal;
 using Etherna.MongODM.Core.Models;
 using Etherna.MongODM.Core.Options;
 using Etherna.MongODM.Core.Repositories;

--- a/test/MongODM.Core.Tests/ExecContext/AsyncLocal/AsyncLocalContextTests.cs
+++ b/test/MongODM.Core.Tests/ExecContext/AsyncLocal/AsyncLocalContextTests.cs
@@ -1,0 +1,169 @@
+// Copyright 2020-present Etherna SA
+// This file is part of MongODM.
+//
+// MongODM is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with MongODM.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Etherna.MongODM.Core.ExecContext.AsyncLocal
+{
+    public class AsyncLocalContextTests
+    {
+        private readonly AsyncLocalContext asyncLocalContext = new();
+
+        [Fact]
+        public void ItemsNullAtCreation()
+        {
+            // Assert.
+            Assert.Null(asyncLocalContext.Items);
+        }
+
+        [Fact]
+        public async Task AsyncLocalLifeCycle()
+        {
+            await Task.Run(async () =>
+            {
+                // Action.
+                asyncLocalContext.InitAsyncLocalContext();
+
+                // Assert.
+                Assert.NotNull(asyncLocalContext.Items);
+                await Task.Run(() =>
+                {
+                    Assert.NotNull(asyncLocalContext.Items);
+                });
+            });
+
+            // Assert.
+            Assert.Null(asyncLocalContext.Items);
+        }
+
+        [Fact]
+        public void SyncLocalLifeCycle()
+        {
+            void localMethod()
+            {
+                // Action.
+                asyncLocalContext.InitAsyncLocalContext();
+
+                // Assert.
+                Assert.NotNull(asyncLocalContext.Items);
+                void subLocalMethod()
+                {
+                    Assert.NotNull(asyncLocalContext.Items);
+                }
+                subLocalMethod();
+            }
+            localMethod();
+
+            // Assert.
+            /* Outside of an async invoker, the container is not automatically disposed. */
+            Assert.NotNull(asyncLocalContext.Items);
+        }
+
+        [Fact]
+        public void ContextDispose()
+        {
+            // Action.
+            using (var handler = asyncLocalContext.InitAsyncLocalContext())
+            {
+                // Assert.
+                Assert.NotNull(asyncLocalContext.Items);
+            }
+
+            // Assert.
+            Assert.Null(asyncLocalContext.Items);
+        }
+
+        [Fact]
+        public void NestedInitializationCreatesIsolatedContext()
+        {
+            // Action.
+            using (var handler0 = AsyncLocalContext.Instance.InitAsyncLocalContext())
+            {
+                var outerItems = asyncLocalContext.Items!;
+                outerItems.Add("outerKey", "outerValue");
+
+                using (var handler1 = AsyncLocalContext.Instance.InitAsyncLocalContext())
+                {
+                    // Assert.
+                    //inner context is new and isolated
+                    Assert.NotNull(asyncLocalContext.Items);
+                    Assert.NotSame(outerItems, asyncLocalContext.Items);
+                    Assert.False(asyncLocalContext.Items!.ContainsKey("outerKey"));
+
+                    asyncLocalContext.Items.Add("innerKey", "innerValue");
+                }
+
+                // Assert.
+                //outer context is restored, untouched by inner one
+                Assert.Same(outerItems, asyncLocalContext.Items);
+                Assert.True(asyncLocalContext.Items!.ContainsKey("outerKey"));
+                Assert.False(asyncLocalContext.Items.ContainsKey("innerKey"));
+            }
+
+            Assert.Null(asyncLocalContext.Items);
+        }
+
+        [Fact]
+        public void SequentialInitializationsOverInheritedContextAreIsolated()
+        {
+            /* Simulate a background job runner: the worker flow inherits an initialized
+             * context from an ancestor flow, and each job opens and disposes its own. */
+            using var inheritedHandler = asyncLocalContext.InitAsyncLocalContext();
+            var inheritedItems = asyncLocalContext.Items!;
+
+            // Action.
+            //first job
+            using (var job0Handler = asyncLocalContext.InitAsyncLocalContext())
+            {
+                asyncLocalContext.Items!.Add("job0Key", "job0Value");
+            }
+
+            //second job
+            using (var job1Handler = asyncLocalContext.InitAsyncLocalContext())
+            {
+                // Assert.
+                //second job doesn't see first job's items
+                Assert.NotSame(inheritedItems, asyncLocalContext.Items);
+                Assert.False(asyncLocalContext.Items!.ContainsKey("job0Key"));
+            }
+
+            // Assert.
+            //inherited context is restored
+            Assert.Same(inheritedItems, asyncLocalContext.Items);
+        }
+
+        [Fact]
+        public void DoubleDisposeDoesntRestoreTwice()
+        {
+            // Setup.
+            using var rootHandler = asyncLocalContext.InitAsyncLocalContext();
+            var rootItems = asyncLocalContext.Items!;
+
+            var innerHandler = asyncLocalContext.InitAsyncLocalContext();
+            innerHandler.Dispose();
+
+            using var currentHandler = asyncLocalContext.InitAsyncLocalContext();
+            var currentItems = asyncLocalContext.Items!;
+
+            // Action.
+            innerHandler.Dispose();
+
+            // Assert.
+            //second dispose of an already disposed handler doesn't replace the current context
+            Assert.Same(currentItems, asyncLocalContext.Items);
+            Assert.NotSame(rootItems, asyncLocalContext.Items);
+        }
+    }
+}

--- a/test/MongODM.Core.Tests/ExecContext/ExecutionContextSelectorTests.cs
+++ b/test/MongODM.Core.Tests/ExecContext/ExecutionContextSelectorTests.cs
@@ -1,0 +1,49 @@
+// Copyright 2020-present Etherna SA
+// This file is part of MongODM.
+//
+// MongODM is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with MongODM.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Moq;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Etherna.MongODM.Core.ExecContext
+{
+    public class ExecutionContextSelectorTests
+    {
+        [Theory]
+        [InlineData(false, false, null)]
+        [InlineData(false, true, "1")]
+        [InlineData(true, false, "0")]
+        [InlineData(true, true, "0")]
+        public void ContextSelection(
+            bool enableContext1,
+            bool enableContext2,
+            string? expectedResult)
+        {
+            // Setup.
+            Mock<IExecutionContext> context0 = new();
+            Mock<IExecutionContext> context1 = new();
+            context0.SetupGet(c => c.Items)
+                .Returns(enableContext1 ? new Dictionary<object, object?> { { "val", "0" } } : null);
+            context1.SetupGet(c => c.Items)
+                .Returns(enableContext2 ? new Dictionary<object, object?> { { "val", "1" } } : null);
+            var selector = new ExecutionContextSelector(new[] { context0.Object, context1.Object });
+
+            // Action.
+            var result = selector.Items?["val"] as string;
+
+            // Assert.
+            Assert.Equal(expectedResult, result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Absorbs the standalone `ExecutionContext` package into MongODM, and fixes the async-local scope isolation bug ([MODM-194](https://etherna.atlassian.net/browse/MODM-194), [EXC-11](https://etherna.atlassian.net/browse/EXC-11)).

### Library import
- Sources vendored into `MongODM.Core/ExecContext/` (namespaces `Etherna.MongODM.Core.ExecContext`, `.AsyncLocal`, `.Exceptions`) and `MongODM.AspNetCore/ExecContext/` (`HttpContextExecutionContext`; `AddExecutionContext()` moved into MongODM's `ServiceCollectionExtensions`).
- `ExecutionContext` / `ExecutionContext.AspNetCore` package references removed; all usings updated.
- Library tests vendored into `MongODM.Core.Tests/ExecContext/`, rewritten against the public API only.

The standalone library will be deprecated: the only other consumer is DomainEvents, tracked in [DOME-9](https://etherna.atlassian.net/browse/DOME-9).

### Isolation fix (MODM-194)
`InitAsyncLocalContext()` now always creates a **new isolated context**, restoring the previous one on handler dispose, instead of joining an inherited dictionary (`??=`). Since `AsyncLocal<T>` values flow down the async call tree, Hangfire workers inherit the app startup context: with the old join semantics, `AsyncLocalContextHangfireFilter` silently attached every job to one shared `Items` dictionary — hence one shared `DbCache` — for the process lifetime, producing stale model reads across jobs (root cause of [EID-256](https://etherna.atlassian.net/browse/EID-256)). With this change the existing filter isolates each job as originally intended.

Note: nested `InitAsyncLocalContext()` calls now get an isolated scope instead of sharing the outer one (reverses EXC-6 semantics); `IsActive` is removed from `IAsyncLocalContextHandler`. `DbExecutionContextHandler` is unaffected: its `Items is null` guard keeps joining existing contexts as before.

## Test
- Solution build clean (warnings as errors), 26/26 tests green.
- New tests cover nested-scope isolation, the inherited-context job-runner scenario, parent restore on dispose, and double-dispose safety.

[MODM-194]: https://etherna.atlassian.net/browse/MODM-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXC-11]: https://etherna.atlassian.net/browse/EXC-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOME-9]: https://etherna.atlassian.net/browse/DOME-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EID-256]: https://etherna.atlassian.net/browse/EID-256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ