### PR TITLE
Add delete from collection with filter

### DIFF
--- a/src/MongODM.Core/Extensions/LoggerExtensions.cs
+++ b/src/MongODM.Core/Extensions/LoggerExtensions.cs
@@ -20,7 +20,7 @@ namespace Etherna.MongODM.Core.Extensions
 {
     /*
      * Always group similar log delegates by type, always use incremental event ids.
-     * Last event id is: 21
+     * Last event id is: 22
      */
     public static class LoggerExtensions
     {
@@ -124,6 +124,12 @@ namespace Etherna.MongODM.Core.Extensions
                 new EventId(15, nameof(RepositoryDeletedDocument)),
                 "Repository {RepositoryName} of DbContext {DbName} deleted document with Id: {ModelId}");
 
+        private static readonly Action<ILogger, string, string, long, Exception> _repositoryDeletedDocuments =
+            LoggerMessage.Define<string, string, long>(
+                LogLevel.Information,
+                new EventId(22, nameof(RepositoryDeletedDocuments)),
+                "Repository {RepositoryName} of DbContext {DbName} deleted {DeletedCount} documents with filter");
+
         private static readonly Action<ILogger, string, string, string, Exception> _repositoryFoundDocument =
             LoggerMessage.Define<string, string, string>(
                 LogLevel.Information,
@@ -196,6 +202,9 @@ namespace Etherna.MongODM.Core.Extensions
 
         public static void RepositoryDeletedDocument(this ILogger logger, string repositoryName, string dbName, string modelId) =>
             _repositoryDeletedDocument(logger, repositoryName, dbName, modelId, null!);
+
+        public static void RepositoryDeletedDocuments(this ILogger logger, string repositoryName, string dbName, long deletedCount) =>
+            _repositoryDeletedDocuments(logger, repositoryName, dbName, deletedCount, null!);
 
         public static void RepositoryFoundDocument(this ILogger logger, string repositoryName, string dbName, string modelId) =>
             _repositoryFoundDocument(logger, repositoryName, dbName, modelId, null!);

--- a/src/MongODM.Core/Repositories/IRepository.cs
+++ b/src/MongODM.Core/Repositories/IRepository.cs
@@ -118,6 +118,38 @@ namespace Etherna.MongODM.Core.Repositories
             FilterDefinition<TModel>[]? additionalFilters = null,
             CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Delete from the collection all the documents matching a filter, without resolving
+        /// their ids. This is a raw bulk operation: it skips the domain level cleanup of the
+        /// model delete, and doesn't touch the changed or loaded models of any db context
+        /// scope. Instances already loaded that match the filter stay on their scope, so
+        /// finds by id on the same scope keep returning them instead of failing as not found
+        /// (remove them explicitly with UnregisterLoadedModel when this matters), but saving
+        /// their changes doesn't recreate the deleted documents.
+        /// </summary>
+        /// <param name="filter">The documents filter</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The number of deleted documents</returns>
+        Task<long> DeleteManyAsync(
+            Expression<Func<TModel, bool>> filter,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete from the collection all the documents matching a filter, without resolving
+        /// their ids. This is a raw bulk operation: it skips the domain level cleanup of the
+        /// model delete, and doesn't touch the changed or loaded models of any db context
+        /// scope. Instances already loaded that match the filter stay on their scope, so
+        /// finds by id on the same scope keep returning them instead of failing as not found
+        /// (remove them explicitly with UnregisterLoadedModel when this matters), but saving
+        /// their changes doesn't recreate the deleted documents.
+        /// </summary>
+        /// <param name="filter">The documents filter</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The number of deleted documents</returns>
+        Task<long> DeleteManyAsync(
+            FilterDefinition<TModel> filter,
+            CancellationToken cancellationToken = default);
+
         Task<CreateIndexModel<TModel>[]> GetDefinedIndexModelsAsync();
 
         Task<TResult> QueryElementsAsync<TResult>(

--- a/src/MongODM.Core/Repositories/Repository.cs
+++ b/src/MongODM.Core/Repositories/Repository.cs
@@ -173,6 +173,23 @@ namespace Etherna.MongODM.Core.Repositories
             await DeleteAsync(castedModel, [], cancellationToken).ConfigureAwait(false);
         }
 
+        public Task<long> DeleteManyAsync(
+            Expression<Func<TModel, bool>> filter,
+            CancellationToken cancellationToken = default) =>
+            DeleteManyAsync(new ExpressionFilterDefinition<TModel>(filter), cancellationToken);
+
+        public Task<long> DeleteManyAsync(
+            FilterDefinition<TModel> filter,
+            CancellationToken cancellationToken = default) =>
+            AccessToCollectionAsync(async collection =>
+            {
+                var result = await collection.DeleteManyAsync(filter, cancellationToken).ConfigureAwait(false);
+
+                logger.RepositoryDeletedDocuments(Name, DbContext.Engine.Options.DbName, result.DeletedCount);
+
+                return result.DeletedCount;
+            });
+
         public async Task DeleteOldIndexesAsync(CancellationToken cancellationToken = default)
         {
             var definedIndexes = await GetDefinedIndexModelsAsync().ConfigureAwait(false);
@@ -647,16 +664,17 @@ namespace Etherna.MongODM.Core.Repositories
                 ArgumentNullException.ThrowIfNull(model);
 
                 // Replace on db.
+                ReplaceOneResult result;
                 if (session == null)
                 {
-                    await collection.ReplaceOneAsync(
+                    result = await collection.ReplaceOneAsync(
                         Builders<TModel>.Filter.Eq(m => m.Id, model.Id),
                         model,
                         cancellationToken: cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
-                    await collection.ReplaceOneAsync(
+                    result = await collection.ReplaceOneAsync(
                         session,
                         Builders<TModel>.Filter.Eq(m => m.Id, model.Id),
                         model,
@@ -664,7 +682,10 @@ namespace Etherna.MongODM.Core.Repositories
                 }
 
                 // Update dependent documents.
-                if (updateDependentDocuments)
+                /* Skip when the replace matched no document: the model has been deleted
+                 * concurrently, like by a bulk delete with filter, and a dependencies
+                 * update task would fail reloading it. */
+                if (updateDependentDocuments && result.MatchedCount > 0)
                     DbContext.Engine.DbMaintainer.OnUpdatedModel<TKey>((IAuditable)model, this);
 
                 // Reset changed members.

--- a/test/MongODM.IntegrationTests/DeleteManyTests.cs
+++ b/test/MongODM.IntegrationTests/DeleteManyTests.cs
@@ -1,0 +1,122 @@
+﻿// Copyright 2020-present Etherna SA
+// This file is part of MongODM.
+//
+// MongODM is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with MongODM.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Etherna.MongODM.Core.ExecContext.AsyncLocal;
+using Etherna.MongODM.IntegrationTests.Fixtures;
+using Etherna.MongODM.IntegrationTests.Models;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Etherna.MongODM.IntegrationTests
+{
+    [Collection("Integration")]
+    public class DeleteManyTests : IDisposable
+    {
+        // Fields.
+        private readonly ITestDbContext dbContext;
+        private readonly IntegrationFixture fixture;
+        private readonly IServiceScope serviceScope;
+
+        // Constructor and dispose.
+        /* Each test runs on its own DI scope, resolving fresh db context instances
+         * like a production request or job would do. */
+        public DeleteManyTests(IntegrationFixture fixture)
+        {
+            this.fixture = fixture;
+            serviceScope = fixture.ServiceProvider.CreateScope();
+            dbContext = serviceScope.ServiceProvider.GetRequiredService<ITestDbContext>();
+        }
+
+        public void Dispose()
+        {
+            serviceScope.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        // Tests.
+        [Fact]
+        public async Task DeleteManyRemovesMatchingDocuments()
+        {
+            // Setup.
+            using var contextHandler = AsyncLocalContext.Instance.InitAsyncLocalContext();
+            var postKeep = new Post("title to keep", "content");
+            var postDelete0 = new Post("title to delete", "content 0");
+            var postDelete1 = new Post("title to delete", "content 1");
+            await dbContext.Posts.CreateAsync(postKeep);
+            await dbContext.Posts.CreateAsync(postDelete0);
+            await dbContext.Posts.CreateAsync(postDelete1);
+
+            // Action.
+            var deletedCount = await dbContext.Posts.DeleteManyAsync(p => p.Title == "title to delete");
+
+            // Assert.
+            Assert.Equal(2, deletedCount);
+
+            using var readScope = fixture.ServiceProvider.CreateScope();
+            var readDbContext = readScope.ServiceProvider.GetRequiredService<ITestDbContext>();
+            using var readContextHandler = AsyncLocalContext.Instance.InitAsyncLocalContext();
+
+            Assert.NotNull(await readDbContext.Posts.TryFindOneAsync(postKeep.Id));
+            Assert.Null(await readDbContext.Posts.TryFindOneAsync(postDelete0.Id));
+            Assert.Null(await readDbContext.Posts.TryFindOneAsync(postDelete1.Id));
+        }
+
+        [Fact]
+        public async Task DeleteManyDoesntTouchTheScopeAndSavesStaySafe()
+        {
+            /* The bulk delete is a raw operation: instances already loaded that match the
+             * filter stay on their scope. A following changes save must not recreate the
+             * deleted document, nor enqueue a dependencies update task doomed to fail. */
+
+            // Setup.
+            using var contextHandler = AsyncLocalContext.Instance.InitAsyncLocalContext();
+            var post = new Post("title", "content");
+            await dbContext.Posts.CreateAsync(post);
+
+            var loadedPost = await dbContext.Posts.FindOneAsync(post.Id);
+            loadedPost.Content = "updated content";
+            Assert.Single(dbContext.ChangedModelsList);
+
+            fixture.TaskRunner.ClearPending();
+
+            // Action.
+            var deletedCount = await dbContext.Posts.DeleteManyAsync(p => p.Id == post.Id);
+
+            // Assert.
+            Assert.Equal(1, deletedCount);
+
+            //raw semantics: the loaded instance stays on the scope, and a find by id
+            //keeps returning it through the identity map instead of failing as not found
+            Assert.Same(loadedPost, dbContext.TryGetLoadedModel(typeof(Post), post.Id!));
+            Assert.Same(loadedPost, await dbContext.Posts.FindOneAsync(post.Id));
+            Assert.Single(dbContext.ChangedModelsList);
+
+            // Action.
+            await dbContext.SaveChangesAsync();
+
+            // Assert.
+            //the save consumed the pending change without recreating the document,
+            //and without enqueueing a dependencies update task
+            Assert.Empty(dbContext.ChangedModelsList);
+            Assert.Equal(0, fixture.TaskRunner.PendingCount);
+
+            using var readScope = fixture.ServiceProvider.CreateScope();
+            var readDbContext = readScope.ServiceProvider.GetRequiredService<ITestDbContext>();
+            using var readContextHandler = AsyncLocalContext.Instance.InitAsyncLocalContext();
+            Assert.Null(await readDbContext.Posts.TryFindOneAsync(post.Id));
+        }
+    }
+}

--- a/test/MongODM.IntegrationTests/Fixtures/InlineTaskRunner.cs
+++ b/test/MongODM.IntegrationTests/Fixtures/InlineTaskRunner.cs
@@ -1,4 +1,4 @@
-// Copyright 2020-present Etherna SA
+﻿// Copyright 2020-present Etherna SA
 // This file is part of MongODM.
 //
 // MongODM is free software: you can redistribute it and/or modify it under the terms of the
@@ -30,6 +30,16 @@ namespace Etherna.MongODM.IntegrationTests.Fixtures
     {
         // Fields.
         private readonly List<Func<IServiceProvider, Task>> pendingTasks = [];
+
+        // Properties.
+        public int PendingCount
+        {
+            get
+            {
+                lock (pendingTasks)
+                    return pendingTasks.Count;
+            }
+        }
 
         // Methods.
         public void ClearPending()


### PR DESCRIPTION
Resolves [MODM-82](https://etherna.atlassian.net/browse/MODM-82).

## What

`IRepository<TModel, TKey>.DeleteManyAsync` (expression and `FilterDefinition` overloads): deletes all the documents matching a filter server side, without resolving their ids, returning the deleted count.

The historical blocker of this issue was DbCache holding references not identifiable without an id. With the per-scope identity map from MODM-179 the blocker dissolves structurally: the map is only consulted when a document is materialized, so a deleted document can never produce a stale hit, and orphan entries are inert and die with the scope.

## Semantics (documented in XML docs)

This is a **raw bulk operation**, complementary to the per-model `DeleteAsync`:
- no domain level cleanup (`DisposeForDelete` + save cascading);
- loaded/changed models of any scope are untouched: instances matching the filter stay on their scope, and finds by id on that scope keep returning them through the identity map instead of failing as not found (`UnregisterLoadedModel` is the explicit escape hatch);
- saving their pending changes doesn't recreate the deleted documents.

## Hardening

`ReplaceOneAsync` results are now checked: when a replace matches no document (deleted concurrently, e.g. by a bulk delete), the dependencies update task is not enqueued, avoiding background failures on reload.

## Tests

Two integration tests: matching documents removal with count; and the composed safety case — load, change, bulk delete, then save: instance stays on the scope (find by id pinned as returning it), no document resurrection, changed list consumed, zero maintenance tasks enqueued.

[MODM-82]: https://etherna.atlassian.net/browse/MODM-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ