### PR TITLE
Add verbose level logs to relevant operations

### DIFF
--- a/src/MongODM.Core/DbContext.cs
+++ b/src/MongODM.Core/DbContext.cs
@@ -66,6 +66,8 @@ namespace Etherna.MongODM.Core
                 if (!repository.IsInitialized)
                     repository.Initialize(this, logger);
             scopedRepositoryRegistry = repositoryRegistry;
+
+            logger.DbContextAttachedToEngine(engine.Options.DbName);
         }
 
         public IDbContextEngine BuildEngine(
@@ -138,8 +140,13 @@ namespace Etherna.MongODM.Core
         {
             ArgumentNullException.ThrowIfNull(model);
 
+            bool registered;
             lock (changedModels)
-                changedModels.Add(model);
+                registered = changedModels.Add(model);
+
+            if (registered &&
+                TryGetRepositoryForModelType(engine.ProxyGenerator.PurgeProxyType(model.GetType())) is { } repository)
+                logger.DbContextRegisteredChangedModel(engine.Options.DbName, repository.ModelIdToString(model), repository.Name);
         }
 
         public void RegisterLoadedModel(object modelId, IEntityModel model)
@@ -153,6 +160,8 @@ namespace Etherna.MongODM.Core
 
             lock (loadedModels)
                 loadedModels[(repository, modelId)] = model;
+
+            logger.DbContextRegisteredLoadedModel(engine.Options.DbName, modelId.ToString()!, repository.Name);
         }
 
         public virtual async Task SaveChangesAsync(CancellationToken cancellationToken = default)
@@ -188,7 +197,10 @@ namespace Etherna.MongODM.Core
             //}
 
             // Commit updated models replacement.
-            foreach (var model in ChangedModelsList)
+            var changedModelsList = ChangedModelsList;
+            logger.DbContextSavingChanges(engine.Options.DbName, changedModelsList.Count);
+
+            foreach (var model in changedModelsList)
             {
                 var modelType = engine.ProxyGenerator.PurgeProxyType(model.GetType());
 
@@ -254,8 +266,14 @@ namespace Etherna.MongODM.Core
             if (repository is null)
                 return null;
 
+            IEntityModel? model;
             lock (loadedModels)
-                return loadedModels.TryGetValue((repository, modelId), out var model) ? model : null;
+                loadedModels.TryGetValue((repository, modelId), out model);
+
+            if (model is not null)
+                logger.DbContextReturnedLoadedModel(engine.Options.DbName, modelId.ToString()!, repository.Name);
+
+            return model;
         }
 
         public Task<DbMigrationOperation?> TryStartMigrationAsync() =>
@@ -265,8 +283,13 @@ namespace Etherna.MongODM.Core
         {
             ArgumentNullException.ThrowIfNull(model);
 
+            bool unregistered;
             lock (changedModels)
-                changedModels.Remove(model);
+                unregistered = changedModels.Remove(model);
+
+            if (unregistered &&
+                TryGetRepositoryForModelType(engine.ProxyGenerator.PurgeProxyType(model.GetType())) is { } repository)
+                logger.DbContextUnregisteredChangedModel(engine.Options.DbName, repository.ModelIdToString(model), repository.Name);
         }
 
         public void UnregisterLoadedModel(object modelId, IEntityModel model)
@@ -278,13 +301,17 @@ namespace Etherna.MongODM.Core
             if (repository is null)
                 return;
 
+            bool unregistered = false;
             lock (loadedModels)
             {
                 //remove only if this same instance is the registered one
                 if (loadedModels.TryGetValue((repository, modelId), out var loadedModel) &&
                     ReferenceEquals(loadedModel, model))
-                    loadedModels.Remove((repository, modelId));
+                    unregistered = loadedModels.Remove((repository, modelId));
             }
+
+            if (unregistered)
+                logger.DbContextUnregisteredLoadedModel(engine.Options.DbName, modelId.ToString()!, repository.Name);
         }
 
         // Protected methods.

--- a/src/MongODM.Core/Extensions/LoggerExtensions.cs
+++ b/src/MongODM.Core/Extensions/LoggerExtensions.cs
@@ -20,12 +20,18 @@ namespace Etherna.MongODM.Core.Extensions
 {
     /*
      * Always group similar log delegates by type, always use incremental event ids.
-     * Last event id is: 23
+     * Last event id is: 38
      */
     public static class LoggerExtensions
     {
         // Fields.
         //*** TRACE LOGS ***
+        private static readonly Action<ILogger, Type, Type, Exception> _proxyModelTypeCreated =
+            LoggerMessage.Define<Type, Type>(
+                LogLevel.Trace,
+                new EventId(32, nameof(ProxyModelTypeCreated)),
+                "ProxyGenerator created proxy type for model type {ModelType}: {ProxyModelType}");
+
         private static readonly Action<ILogger, string, string, Exception> _repositoryAccessedCollection =
             LoggerMessage.Define<string, string>(
                 LogLevel.Trace,
@@ -33,11 +39,47 @@ namespace Etherna.MongODM.Core.Extensions
                 "Repository {RepositoryName} of DbContext {DbName} accessed collection");
 
         //*** DEBUG LOGS ***
+        private static readonly Action<ILogger, string, string, string, Exception> _dbContextRegisteredChangedModel =
+            LoggerMessage.Define<string, string, string>(
+                LogLevel.Trace,
+                new EventId(25, nameof(DbContextRegisteredChangedModel)),
+                "DbContext {DbName} registered changed model with Id {ModelId} of repository {RepositoryName}");
+
+        private static readonly Action<ILogger, string, string, string, Exception> _dbContextRegisteredLoadedModel =
+            LoggerMessage.Define<string, string, string>(
+                LogLevel.Trace,
+                new EventId(26, nameof(DbContextRegisteredLoadedModel)),
+                "DbContext {DbName} registered loaded model with Id {ModelId} of repository {RepositoryName}");
+
+        private static readonly Action<ILogger, string, string, string, Exception> _dbContextReturnedLoadedModel =
+            LoggerMessage.Define<string, string, string>(
+                LogLevel.Trace,
+                new EventId(27, nameof(DbContextReturnedLoadedModel)),
+                "DbContext {DbName} returned already loaded model with Id {ModelId} of repository {RepositoryName}");
+
         private static readonly Action<ILogger, string, string, string, Exception> _dbContextSavedChangedModelToRepository =
             LoggerMessage.Define<string, string, string>(
                 LogLevel.Debug,
                 new EventId(3, nameof(DbContextSavedChangedModelToRepository)),
                 "DbContext {DbName} saved changed model with Id {ModelId} on repository {RepositoryName}");
+
+        private static readonly Action<ILogger, string, string, string, Exception> _dbContextUnregisteredChangedModel =
+            LoggerMessage.Define<string, string, string>(
+                LogLevel.Trace,
+                new EventId(29, nameof(DbContextUnregisteredChangedModel)),
+                "DbContext {DbName} unregistered changed model with Id {ModelId} of repository {RepositoryName}");
+
+        private static readonly Action<ILogger, string, string, string, Exception> _dbContextUnregisteredLoadedModel =
+            LoggerMessage.Define<string, string, string>(
+                LogLevel.Trace,
+                new EventId(30, nameof(DbContextUnregisteredLoadedModel)),
+                "DbContext {DbName} unregistered loaded model with Id {ModelId} of repository {RepositoryName}");
+
+        private static readonly Action<ILogger, string, Type, string, int, Exception> _dbMaintainerEnqueuedDependenciesUpdateTask =
+            LoggerMessage.Define<string, Type, string, int>(
+                LogLevel.Trace,
+                new EventId(31, nameof(DbMaintainerEnqueuedDependenciesUpdateTask)),
+                "DbMaintainer of DbContext {DbName} enqueued dependencies update task for model {ModelType} with Id {ModelId} on {IdMemberMapsCount} id member maps");
 
         private static readonly Action<ILogger, string, Exception> _dbMaintainerInitialized =
             LoggerMessage.Define<string>(
@@ -69,6 +111,24 @@ namespace Etherna.MongODM.Core.Extensions
                 new EventId(5, nameof(RepositoryRegistryInitialized)),
                 "RepositoryRegistry of DbContext {DbName} initialized");
 
+        private static readonly Action<ILogger, string, string, string, string, Exception> _repositorySaveFellBackToDocumentReplace =
+            LoggerMessage.Define<string, string, string, string>(
+                LogLevel.Trace,
+                new EventId(34, nameof(RepositorySaveFellBackToDocumentReplace)),
+                "Repository {RepositoryName} of DbContext {DbName} saving changes of document with Id: {ModelId} fell back to document replace: {Reason}");
+
+        private static readonly Action<ILogger, string, string, string, Exception> _repositorySkippedDependenciesUpdate =
+            LoggerMessage.Define<string, string, string>(
+                LogLevel.Trace,
+                new EventId(35, nameof(RepositorySkippedDependenciesUpdate)),
+                "Repository {RepositoryName} of DbContext {DbName} skipped dependencies update of not found document with Id: {ModelId}");
+
+        private static readonly Action<ILogger, string, string, bool, Exception> _repositoryUpsertedDocument =
+            LoggerMessage.Define<string, string, bool>(
+                LogLevel.Trace,
+                new EventId(36, nameof(RepositoryUpsertedDocument)),
+                "Repository {RepositoryName} of DbContext {DbName} upserted document, inserted: {Inserted}");
+
         private static readonly Action<ILogger, string, Exception> _schemaRegistryInitialized =
             LoggerMessage.Define<string>(
                 LogLevel.Debug,
@@ -82,6 +142,12 @@ namespace Etherna.MongODM.Core.Extensions
                 "Summary model of type {ModelType} with id {ModelId} full loaded");
 
         //*** INFORMATION LOGS ***
+        private static readonly Action<ILogger, string, Exception> _dbContextAttachedToEngine =
+            LoggerMessage.Define<string>(
+                LogLevel.Trace,
+                new EventId(24, nameof(DbContextAttachedToEngine)),
+                "DbContext {DbName} attached a new instance to its engine");
+
         private static readonly Action<ILogger, string, Exception> _dbContextInitialized =
             LoggerMessage.Define<string>(
                 LogLevel.Information,
@@ -93,6 +159,12 @@ namespace Etherna.MongODM.Core.Extensions
                 LogLevel.Information,
                 new EventId(1, nameof(DbContextSavedChanges)),
                 "DbContext {DbName} saved changes");
+
+        private static readonly Action<ILogger, string, int, Exception> _dbContextSavingChanges =
+            LoggerMessage.Define<string, int>(
+                LogLevel.Trace,
+                new EventId(28, nameof(DbContextSavingChanges)),
+                "DbContext {DbName} saving changes of {ChangedModelsCount} models");
 
         private static readonly Action<ILogger, string, Exception> _dbContextSeeded =
             LoggerMessage.Define<string>(
@@ -130,6 +202,12 @@ namespace Etherna.MongODM.Core.Extensions
                 new EventId(22, nameof(RepositoryDeletedDocuments)),
                 "Repository {RepositoryName} of DbContext {DbName} deleted {DeletedCount} documents with filter");
 
+        private static readonly Action<ILogger, string, string, bool, Exception> _repositoryFoundAndUpdatedDocument =
+            LoggerMessage.Define<string, string, bool>(
+                LogLevel.Trace,
+                new EventId(33, nameof(RepositoryFoundAndUpdatedDocument)),
+                "Repository {RepositoryName} of DbContext {DbName} executed find and update on a document, matched: {Matched}");
+
         private static readonly Action<ILogger, string, string, string, Exception> _repositoryFoundDocument =
             LoggerMessage.Define<string, string, string>(
                 LogLevel.Information,
@@ -154,6 +232,18 @@ namespace Etherna.MongODM.Core.Extensions
                 new EventId(23, nameof(RepositorySavedModelChanges)),
                 "Repository {RepositoryName} of DbContext {DbName} saved changed members of document with Id: {ModelId}");
 
+        private static readonly Action<ILogger, Type, string, Exception> _summaryModelMergedFullModel =
+            LoggerMessage.Define<Type, string>(
+                LogLevel.Trace,
+                new EventId(37, nameof(SummaryModelMergedFullModel)),
+                "Summary model {ModelType} with Id {ModelId} merged with its full model");
+
+        private static readonly Action<ILogger, Type, string, Exception> _summaryModelMergedSummaryModel =
+            LoggerMessage.Define<Type, string>(
+                LogLevel.Trace,
+                new EventId(38, nameof(SummaryModelMergedSummaryModel)),
+                "Summary model {ModelType} with Id {ModelId} merged with another summary model");
+
         private static readonly Action<ILogger, Type, string, string, Exception> _updateDocDependenciesTaskEnded =
             LoggerMessage.Define<Type, string, string>(
                 LogLevel.Information,
@@ -173,8 +263,20 @@ namespace Etherna.MongODM.Core.Extensions
         //*** FATAL LOGS ***
 
         // Methods.
+        public static void DbContextAttachedToEngine(this ILogger logger, string dbName) =>
+            _dbContextAttachedToEngine(logger, dbName, null!);
+
         public static void DbContextInitialized(this ILogger logger, string dbName) =>
             _dbContextInitialized(logger, dbName, null!);
+
+        public static void DbContextRegisteredChangedModel(this ILogger logger, string dbName, string modelId, string repositoryName) =>
+            _dbContextRegisteredChangedModel(logger, dbName, modelId, repositoryName, null!);
+
+        public static void DbContextRegisteredLoadedModel(this ILogger logger, string dbName, string modelId, string repositoryName) =>
+            _dbContextRegisteredLoadedModel(logger, dbName, modelId, repositoryName, null!);
+
+        public static void DbContextReturnedLoadedModel(this ILogger logger, string dbName, string modelId, string repositoryName) =>
+            _dbContextReturnedLoadedModel(logger, dbName, modelId, repositoryName, null!);
 
         public static void DbContextSavedChangedModelToRepository(this ILogger logger, string dbName, string modelId, string repositoryName) =>
             _dbContextSavedChangedModelToRepository(logger, dbName, modelId, repositoryName, null!);
@@ -182,8 +284,20 @@ namespace Etherna.MongODM.Core.Extensions
         public static void DbContextSavedChanges(this ILogger logger, string dbName) =>
             _dbContextSavedChanges(logger, dbName, null!);
 
+        public static void DbContextSavingChanges(this ILogger logger, string dbName, int changedModelsCount) =>
+            _dbContextSavingChanges(logger, dbName, changedModelsCount, null!);
+
         public static void DbContextSeeded(this ILogger logger, string dbName) =>
             _dbContextSeeded(logger, dbName, null!);
+
+        public static void DbContextUnregisteredChangedModel(this ILogger logger, string dbName, string modelId, string repositoryName) =>
+            _dbContextUnregisteredChangedModel(logger, dbName, modelId, repositoryName, null!);
+
+        public static void DbContextUnregisteredLoadedModel(this ILogger logger, string dbName, string modelId, string repositoryName) =>
+            _dbContextUnregisteredLoadedModel(logger, dbName, modelId, repositoryName, null!);
+
+        public static void DbMaintainerEnqueuedDependenciesUpdateTask(this ILogger logger, string dbName, Type modelType, string modelId, int idMemberMapsCount) =>
+            _dbMaintainerEnqueuedDependenciesUpdateTask(logger, dbName, modelType, modelId, idMemberMapsCount, null!);
 
         public static void DbMaintainerInitialized(this ILogger logger, string dbName) =>
             _dbMaintainerInitialized(logger, dbName, null!);
@@ -193,6 +307,9 @@ namespace Etherna.MongODM.Core.Extensions
 
         public static void DiscriminatorRegistryInitialized(this ILogger logger, string dbName) =>
             _discriminatorRegistryInitialized(logger, dbName, null!);
+
+        public static void ProxyModelTypeCreated(this ILogger logger, Type modelType, Type proxyModelType) =>
+            _proxyModelTypeCreated(logger, modelType, proxyModelType, null!);
 
         public static void RepositoryAccessedCollection(this ILogger logger, string repositoryName, string dbName) =>
             _repositoryAccessedCollection(logger, repositoryName, dbName, null!);
@@ -212,6 +329,9 @@ namespace Etherna.MongODM.Core.Extensions
         public static void RepositoryDeletedDocuments(this ILogger logger, string repositoryName, string dbName, long deletedCount) =>
             _repositoryDeletedDocuments(logger, repositoryName, dbName, deletedCount, null!);
 
+        public static void RepositoryFoundAndUpdatedDocument(this ILogger logger, string repositoryName, string dbName, bool matched) =>
+            _repositoryFoundAndUpdatedDocument(logger, repositoryName, dbName, matched, null!);
+
         public static void RepositoryFoundDocument(this ILogger logger, string repositoryName, string dbName, string modelId) =>
             _repositoryFoundDocument(logger, repositoryName, dbName, modelId, null!);
 
@@ -230,11 +350,26 @@ namespace Etherna.MongODM.Core.Extensions
         public static void RepositorySavedModelChanges(this ILogger logger, string repositoryName, string dbName, string modelId) =>
             _repositorySavedModelChanges(logger, repositoryName, dbName, modelId, null!);
 
+        public static void RepositorySaveFellBackToDocumentReplace(this ILogger logger, string repositoryName, string dbName, string modelId, string reason) =>
+            _repositorySaveFellBackToDocumentReplace(logger, repositoryName, dbName, modelId, reason, null!);
+
+        public static void RepositorySkippedDependenciesUpdate(this ILogger logger, string repositoryName, string dbName, string modelId) =>
+            _repositorySkippedDependenciesUpdate(logger, repositoryName, dbName, modelId, null!);
+
+        public static void RepositoryUpsertedDocument(this ILogger logger, string repositoryName, string dbName, bool inserted) =>
+            _repositoryUpsertedDocument(logger, repositoryName, dbName, inserted, null!);
+
         public static void SchemaRegistryInitialized(this ILogger logger, string dbName) =>
             _schemaRegistryInitialized(logger, dbName, null!);
 
         public static void SummaryModelFullLoaded(this ILogger logger, Type modelType, string modelId) =>
             _summaryModelFullLoaded(logger, modelType, modelId, null!);
+
+        public static void SummaryModelMergedFullModel(this ILogger logger, Type modelType, string modelId) =>
+            _summaryModelMergedFullModel(logger, modelType, modelId, null!);
+
+        public static void SummaryModelMergedSummaryModel(this ILogger logger, Type modelType, string modelId) =>
+            _summaryModelMergedSummaryModel(logger, modelType, modelId, null!);
 
         public static void UpdateDocDependenciesTaskEnded(this ILogger logger, Type dbContextType, string referencedRepositoryName, string modelId) =>
             _updateDocDependenciesTaskEnded(logger, dbContextType, referencedRepositoryName, modelId, null!);

--- a/src/MongODM.Core/ProxyModels/ProxyGenerator.cs
+++ b/src/MongODM.Core/ProxyModels/ProxyGenerator.cs
@@ -15,6 +15,7 @@
 using Castle.DynamicProxy;
 using Etherna.MongODM.Core.Domain.Models;
 using Etherna.MongODM.Core.ExecContext;
+using Etherna.MongODM.Core.Extensions;
 using Etherna.MongODM.Core.Utility;
 using Microsoft.Extensions.Logging;
 using System;
@@ -33,6 +34,7 @@ namespace Etherna.MongODM.Core.ProxyModels
     {
         // Fields.
         private bool disposed;
+        private readonly ILogger<ProxyGenerator> logger = loggerFactory.CreateLogger<ProxyGenerator>();
 
         private readonly Dictionary<Type,
             (Type[] AdditionalInterfaces, Func<IDbContextEngine, IInterceptor[]> InterceptorInstancerSelector)> modelConfigurationDictionary = new();
@@ -157,6 +159,7 @@ namespace Etherna.MongODM.Core.ProxyModels
                     if (!proxyTypeDictionary.ContainsKey(type))
                     {
                         proxyTypeDictionary.Add(type, proxyModel.GetType());
+                        logger.ProxyModelTypeCreated(type, proxyModel.GetType());
                     }
                 }
                 finally

--- a/src/MongODM.Core/ProxyModels/ReferenceableInterceptor.cs
+++ b/src/MongODM.Core/ProxyModels/ReferenceableInterceptor.cs
@@ -204,6 +204,8 @@ namespace Etherna.MongODM.Core.ProxyModels
 
             // Reenable auditing.
             (model as IAuditable)?.EnableAuditing();
+
+            logger.SummaryModelMergedSummaryModel(typeof(TModel), model.Id?.ToString() ?? string.Empty);
         }
 
         private void MergeFullModel(TModel model, TModel? fullModel)
@@ -224,6 +226,8 @@ namespace Etherna.MongODM.Core.ProxyModels
 
                 // Reenable auditing.
                 (model as IAuditable)?.EnableAuditing();
+
+                logger.SummaryModelMergedFullModel(typeof(TModel), model.Id?.ToString() ?? string.Empty);
             }
 
             isSummary = false;

--- a/src/MongODM.Core/Repositories/Repository.cs
+++ b/src/MongODM.Core/Repositories/Repository.cs
@@ -391,10 +391,16 @@ namespace Etherna.MongODM.Core.Repositories
                 throw new MongodmInvalidEntityTypeException("Invalid model type");
 
             // Fallback to a whole document replace when member level update isn't applicable.
-            if (options.SaveWithDocumentReplace ||
-                model is not IAuditable auditableModel ||
+            if (options.SaveWithDocumentReplace)
+            {
+                logger.RepositorySaveFellBackToDocumentReplace(Name, DbContext.Engine.Options.DbName, castedModel.Id!.ToString()!, "document replace is required by repository options");
+                await ReplaceAsync(castedModel, cancellationToken: cancellationToken).ConfigureAwait(false);
+                return;
+            }
+            if (model is not IAuditable auditableModel ||
                 model is not IReferenceable)
             {
+                logger.RepositorySaveFellBackToDocumentReplace(Name, DbContext.Engine.Options.DbName, castedModel.Id!.ToString()!, "model is not trackable member level");
                 await ReplaceAsync(castedModel, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return;
             }
@@ -416,6 +422,7 @@ namespace Etherna.MongODM.Core.Repositories
                 {
                     /* A changed member not mapped by the active schema can't be updated
                      * member level: persist with a whole document replace. */
+                    logger.RepositorySaveFellBackToDocumentReplace(Name, DbContext.Engine.Options.DbName, castedModel.Id!.ToString()!, $"changed member {memberInfo.Name} is not mapped by the active schema");
                     await ReplaceAsync(castedModel, cancellationToken: cancellationToken).ConfigureAwait(false);
                     return;
                 }
@@ -435,6 +442,7 @@ namespace Etherna.MongODM.Core.Repositories
 
             if (update.ElementCount == 0)
             {
+                logger.RepositorySaveFellBackToDocumentReplace(Name, DbContext.Engine.Options.DbName, castedModel.Id!.ToString()!, "no serializable changed members");
                 await ReplaceAsync(castedModel, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return;
             }
@@ -468,6 +476,7 @@ namespace Etherna.MongODM.Core.Repositories
              * and skips silently the deleted documents. */
             if (updatedModel is null)
             {
+                logger.RepositorySaveFellBackToDocumentReplace(Name, DbContext.Engine.Options.DbName, castedModel.Id!.ToString()!, "document is not serialized with the active schema, or is deleted");
                 await ReplaceAsync(castedModel, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return;
             }
@@ -518,10 +527,16 @@ namespace Etherna.MongODM.Core.Repositories
             FilterDefinition<TModel> filter,
             UpdateDefinition<TModel> update,
             FindOneAndUpdateOptions<TModel> options,
-            CancellationToken cancellationToken = default) =>
-            await AccessToCollectionAsync(async collection =>
+            CancellationToken cancellationToken = default)
+        {
+            var model = await AccessToCollectionAsync(async collection =>
                 await collection.FindOneAndUpdateAsync(filter, update, options, cancellationToken)
                     .ConfigureAwait(false)).ConfigureAwait(false);
+
+            logger.RepositoryFoundAndUpdatedDocument(Name, DbContext.Engine.Options.DbName, model is not null);
+
+            return model;
+        }
 
         public async Task<object?> TryFindOneAsync(object id, CancellationToken cancellationToken = default) =>
             await TryFindOneAsync((TKey)id, cancellationToken).ConfigureAwait(false);
@@ -648,6 +663,8 @@ namespace Etherna.MongODM.Core.Repositories
                     (oldDocument as IAuditable)?.DisableAuditing();
                     DbContext.UnregisterLoadedModel(oldDocument.Id!, oldDocument);
                 }
+
+                logger.RepositoryUpsertedDocument(Name, DbContext.Engine.Options.DbName, oldDocument is null);
 
                 return oldDocument;
             });
@@ -821,8 +838,13 @@ namespace Etherna.MongODM.Core.Repositories
                 /* Skip when the replace matched no document: the model has been deleted
                  * concurrently, like by a bulk delete with filter, and a dependencies
                  * update task would fail reloading it. */
-                if (updateDependentDocuments && result.MatchedCount > 0)
-                    DbContext.Engine.DbMaintainer.OnUpdatedModel<TKey>((IAuditable)model, this);
+                if (updateDependentDocuments)
+                {
+                    if (result.MatchedCount > 0)
+                        DbContext.Engine.DbMaintainer.OnUpdatedModel<TKey>((IAuditable)model, this);
+                    else
+                        logger.RepositorySkippedDependenciesUpdate(Name, DbContext.Engine.Options.DbName, model.Id!.ToString()!);
+                }
 
                 // Reset changed members.
                 ((IAuditable)model).ResetChangedMembers();

--- a/src/MongODM.Core/Utility/DbMaintainer.cs
+++ b/src/MongODM.Core/Utility/DbMaintainer.cs
@@ -108,12 +108,21 @@ namespace Etherna.MongODM.Core.Utility
              * We pass member maps' string ids because strings are better serializable by the task executor.
              * All member maps must be recovered by the task using Ids from the schema register.
              */
+            var idMemberMapIds = allIdMemberMaps.Select(mm => mm.Id).ToArray();
+            var updatedModelId = ((IEntityModel<TKey>)updatedModel).Id!;
+
             taskRunner.RunUpdateDocDependenciesTask(
                 dbContextEngine.DbContextType,
                 referenceRepository.Name,
-                ((IEntityModel<TKey>)updatedModel).Id!,
-                allIdMemberMaps.Select(mm => mm.Id),
+                updatedModelId,
+                idMemberMapIds,
                 ExclusiveAccessHandler.IsExclusiveAccessAllowed(dbContextEngine.ExecutionContext));
+
+            logger.DbMaintainerEnqueuedDependenciesUpdateTask(
+                dbContextEngine.Options.DbName,
+                dbContextEngine.ProxyGenerator.PurgeProxyType(updatedModel.GetType()),
+                updatedModelId.ToString()!,
+                idMemberMapIds.Length);
         }
     }
 }


### PR DESCRIPTION
Resolves [MODM-197](https://etherna.atlassian.net/browse/MODM-197).

## What

Fifteen new log events (ids 24-38), all at **Trace level** (the level mapped to Serilog's Verbose by the applications), covering the operations born with the scoped db contexts refactor that had no logging:

**Db context scope lifecycle**: instance attached to its engine; changed and loaded models registered/unregistered (with model id and repository name, logged only on actual state transitions); identity map hits (covering both serializer deduplication and the `FindOneAsync` read-through); changes save start with the changed models count.

**Repository**: save fallback to document replace **with the reason** (repository options / model not trackable / changed member not mapped by active schema / document not on active schema or deleted); skipped dependencies update on documents matched by no replace; upserts (with inserted flag) and find-and-update executions (with matched flag).

**Infrastructure**: dependencies update task enqueueing (model type, id, involved member maps count — correlatable with the Hangfire task events); proxy model type generation (once per type, `ProxyGenerator` gets its own logger); summary model merges with full and with summary models.

Pre-existing 23 events keep their levels untouched. Header updated to `Last event id is: 38`.

## Deliberately out of scope

Serializer-internal events (serializers have no `ILogger` plumbing — threading it would be a structural change disproportionate for logging), execution context handler push/pop (one per operation, pure noise), per-instance proxy creations (per-type generation suffices).

[MODM-197]: https://etherna.atlassian.net/browse/MODM-197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ