### PR TITLE
Enforce uniqueness of model map schema ids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Five source projects (one NuGet package each), two test projects, one sample:
 - **`src/MongODM.Core`** (`Etherna.MongODM.Core`) — The framework itself, host-agnostic. Main areas:
   - `DbContext.cs` / `IDbContext.cs` / `DbContextEngine.cs` / `IDbContextEngine.cs` — unit of work and its engine, related by composition (`IDbContext` does NOT extend `IDbContextEngine`). `DbContextEngine` owns the scope independent members built once at initialization (connections, schema registries, seeding cache, exclusive access locking with `RunWithExclusiveAccessAsync`), and is the type captured by the serialization pipeline; `DbContext` attaches to its engine (exposed as `IDbContext.Engine`) and owns the current unit of work state (`ChangedModelsList`, `SaveChangesAsync`, per-instance repositories, migration facades, `ExecuteInTransactionAsync`).
   - `Repositories/` — `Repository<TModel, TKey>` with typed access to collections; every collection access passes through `AccessToCollectionAsync`.
-  - `Serialization/` — model maps and versioned schemas (`MapRegistry`, `ModelMap`, member maps), discriminator registry, serializers and modifiers.
+  - `Serialization/` — model maps and versioned schemas (`MapRegistry`, `ModelMap`, member maps), discriminator registry, serializers and modifiers. Model map schema ids must be unique across the whole db context, not only inside their model map, with the `fallback` id reserved to fallback schemas: violations fail fast at engine build with a detailed `MongodmDuplicateSchemaIdException`. Reference serializer configurations are separate id spaces (their summary schema ids can mirror the root ones) and stay out of the check.
   - `ProxyModels/` — Castle DynamicProxy-based model proxies enabling lazy loading and change auditing (`IAuditable`).
   - `Migration/` — `DocumentMigration` scripts between document schemas.
   - `Tasks/` — background tasks invoked through `ITaskRunner` (`UpdateDocDependenciesTask` propagates updated summaries to referencing documents; `MigrateDbContextTask` runs a db context migration under exclusive access).
@@ -83,7 +83,7 @@ After the library work, the Etherna services must be migrated: see [SERVICES-MIG
 - **Classes/Structs**: PascalCase (`DbMigrationManager`, `ModelMap`)
 - **Interfaces**: `I` prefix (`IDbContext`, `ITaskRunner`)
 - **Async methods**: always `Async` suffix (`SaveChangesAsync`, `FindOneAsync`)
-- **Properties**: PascalCase (`IsSeeded`, `CurrentStatus`)
+- **Properties**: PascalCase, with `Is`/`Has` prefix for booleans (`IsSeeded`, `CurrentStatus`)
 - **Private fields**: `_camelCase` only when backing a same-named property (`_isSeeded` for `IsSeeded`); otherwise plain `camelCase`
 - **Primary constructor parameters**: `camelCase` without underscore
 - **Constants**: PascalCase (`HandlerKey`)
@@ -113,6 +113,8 @@ Secondary/separator comments:
 ```
 
 Longer explanations of non-obvious behavior use `/* ... */` blocks. Comment only what helps a future reader: non-obvious behavior, intent, or a gotcha. Do **not** write narration of your own reasoning or decisions — that belongs in the commit message / PR description, never in committed code.
+
+Public API members are documented with XML doc comments (`///`), with a well-composed description and no superfluous information; document non-public members too whenever it aids understanding.
 
 ## Member Ordering Within a Class
 
@@ -145,6 +147,7 @@ private void InternalHelper() { ... }
 
 - `internal sealed` for implementations that aren't part of the public API
 - Primary constructors everywhere the constructor is a simple assignment
+- Don't extract a private helper method for logic used in a single place — inline it. Reserve helpers for code shared by two or more call sites (or when extraction materially clarifies an otherwise long, complex method)
 - Framework-initialized components implement `IDbContextEngineInitializable` (engine level: registries, maintainer, migration manager) or `IDbContextInitializable` (scope level: repositories and their registry) — `Initialize(..., logger)` + `IsInitialized` guard instead of taking the dependency in the constructor
 
 ### Persisted Model Classes
@@ -184,8 +187,12 @@ private void InternalHelper() { ... }
 - Switch expressions for multi-branch returns
 - Primary constructors everywhere applicable
 - Collection expressions: `[]`, `[..spread]`
-- Prefer collection expressions over constructors to initialize any collection: `[]` not `new()`, `["a", "b"]` not `new List<string> { "a", "b" }`. Use a constructor only when a collection expression can't express the intent (e.g. presizing capacity with `new List<T>(capacity)`).
+- Prefer collection expressions over constructors to initialize any collection (lists, arrays, dictionaries, etc.): `[]` not `new()`, `["a", "b"]` not `new List<string> { "a", "b" }`. Use a constructor only when a collection expression can't express the intent (e.g. presizing capacity with `new List<T>(capacity)`, or building a specific set type like `new HashSet<T>(value ?? [])`). This applies also where the surrounding legacy code still uses constructors: new code follows the rule, not the neighbors.
 - Target-typed `new()` when type is clear from context (for non-collection types)
+- Tuple deconstruction for multiple return values
+- Prefer a property pattern over a chain of `&&` combining a type/null check with member accesses: it expresses the condition as a single declarative shape the value must match, rather than an imperative sequence of checks
+- `field` keyword for field-backed properties (e.g. lazy initialization) instead of an explicit backing field: `public T Prop => field ??= Compute();`. Needs C# 14: in `src/` it applies only once the `net8.0`/`net9.0` targets are dropped (each TFM compiles with its default LangVersion); the net10-only test projects can use it today
+- Lock fields: prefer the dedicated `System.Threading.Lock` type (.NET 9+) over a plain `object` — more expressive, and the compiler enforces correct `lock` usage on it. In `src/` it applies only once the `net8.0` target is dropped (lowest-target rule); the net10-only test projects can use it today
 
 ## LINQ
 
@@ -195,6 +202,7 @@ private void InternalHelper() { ... }
 
 ## Testing (xUnit + Moq)
 
+- AAA pattern with section comments: `// Setup.`, `// Action.`, `// Assert.` (collapse when a single statement covers two phases)
 - `[Fact]` for basic tests, `[Theory]` with `[InlineData]`/`[MemberData]` for parameterized cases
 - xUnit assertions: `Assert.Equal()`, `Assert.NotNull()`, `Assert.ThrowsAsync<T>()`
 - Moq for mocking: `new Mock<IDbContext>()`

--- a/src/MongODM.Core/Exceptions/MongodmDuplicateSchemaIdException.cs
+++ b/src/MongODM.Core/Exceptions/MongodmDuplicateSchemaIdException.cs
@@ -1,0 +1,31 @@
+// Copyright 2020-present Etherna SA
+// This file is part of MongODM.
+//
+// MongODM is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with MongODM.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+
+namespace Etherna.MongODM.Core.Exceptions
+{
+    public class MongodmDuplicateSchemaIdException : Exception
+    {
+        // Constructors.
+        public MongodmDuplicateSchemaIdException()
+        { }
+
+        public MongodmDuplicateSchemaIdException(string message) : base(message)
+        { }
+
+        public MongodmDuplicateSchemaIdException(string message, Exception innerException) : base(message, innerException)
+        { }
+    }
+}

--- a/src/MongODM.Core/Serialization/Mapping/MapRegistry.cs
+++ b/src/MongODM.Core/Serialization/Mapping/MapRegistry.cs
@@ -225,6 +225,9 @@ namespace Etherna.MongODM.Core.Serialization.Mapping
 
         protected override void FreezeAction()
         {
+            // Verify uniqueness of model map schema ids.
+            ValidateSchemaIds();
+
             // Link model maps with their base map.
             LinkBaseModelMaps();
 
@@ -469,6 +472,41 @@ namespace Etherna.MongODM.Core.Serialization.Mapping
             }
 
             memberMapListByElementPath.Add(memberMap);
+        }
+
+        /* Model map schema ids identify on documents the schema shaping them, and must be
+         * unique across the whole db context, not only inside their model map: reusing an
+         * id on different model types is a source of misunderstandings. The fallback
+         * schema id is a sentinel shared by all fallback schemas, and is reserved to them. */
+        private void ValidateSchemaIds()
+        {
+            Dictionary<string, List<IModelMapSchema>> schemasById = [];
+            foreach (var modelMap in _maps.Values.OfType<IModelMap>())
+            {
+                foreach (var schema in modelMap.SecondarySchemas.Prepend(modelMap.ActiveSchema))
+                {
+                    if (!schemasById.TryGetValue(schema.Id, out var schemas))
+                    {
+                        schemas = [];
+                        schemasById.Add(schema.Id, schemas);
+                    }
+                    schemas.Add(schema);
+                }
+            }
+
+            List<string> violations = [];
+            foreach (var (id, schemas) in schemasById)
+            {
+                if (id == ModelMapSchema.FallbackId)
+                    violations.Add($"schema id \"{id}\" is reserved to fallback schemas, and is used by model types {string.Join(", ", schemas.Select(s => s.ModelMap.ModelType.Name))}");
+                else if (schemas.Count > 1)
+                    violations.Add($"schema id \"{id}\" is used by model types {string.Join(", ", schemas.Select(s => s.ModelMap.ModelType.Name))}");
+            }
+
+            if (violations.Count > 0)
+                throw new MongodmDuplicateSchemaIdException(
+                    $"DbContext {dbContextEngine.DbContextType.Name} has model map schemas violating id uniqueness: " +
+                    string.Join("; ", violations));
         }
     }
 }

--- a/src/MongODM.Core/Serialization/Mapping/ModelMap.cs
+++ b/src/MongODM.Core/Serialization/Mapping/ModelMap.cs
@@ -238,7 +238,7 @@ namespace Etherna.MongODM.Core.Serialization.Mapping
             Func<IDbContext, TModel, Task<TModel>>? fixDeserializedModelFunc = null)
         {
             AddFallbackModelMapSchemaHelper(new ModelMapSchema<TModel>(
-                "fallback",
+                ModelMapSchema.FallbackId,
                 new BsonClassMap<TModel>(modelMapSchemaInitializer ?? (cm => cm.AutoMap())),
                 baseSchemaId,
                 fixDeserializedModelFunc,

--- a/src/MongODM.Core/Serialization/Mapping/ModelMapSchema.cs
+++ b/src/MongODM.Core/Serialization/Mapping/ModelMapSchema.cs
@@ -26,6 +26,11 @@ namespace Etherna.MongODM.Core.Serialization.Mapping
 {
     public abstract class ModelMapSchema : FreezableConfig, IModelMapSchema
     {
+        // Consts.
+        /* Sentinel id shared by all fallback schemas: it doesn't identify a schema
+         * version on documents, and is reserved to them. */
+        public const string FallbackId = "fallback";
+
         // Fields.
         private readonly List<IMemberMap> _generatedMemberMaps = new();
         private readonly BsonClassMap bsonClassMap;

--- a/test/MongODM.Core.UnitTests/MapRegistryTest.cs
+++ b/test/MongODM.Core.UnitTests/MapRegistryTest.cs
@@ -1,0 +1,162 @@
+// Copyright 2020-present Etherna SA
+// This file is part of MongODM.
+//
+// MongODM is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with MongODM.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Etherna.MongoDB.Bson.Serialization;
+using Etherna.MongODM.Core.Exceptions;
+using Etherna.MongODM.Core.Models;
+using Etherna.MongODM.Core.Options;
+using Etherna.MongODM.Core.Serialization.Mapping;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using Xunit;
+
+namespace Etherna.MongODM.Core
+{
+    public class MapRegistryTest
+    {
+        // Internal classes.
+        public class FirstModel
+        {
+            public string? Name { get; set; }
+        }
+        public class SecondModel
+        {
+            public string? Name { get; set; }
+        }
+
+        // Fields.
+        private readonly Mock<IDbContextEngine> dbContextEngineMock = new();
+        private readonly MapRegistry mapRegistry = new();
+
+        // Constructor.
+        public MapRegistryTest()
+        {
+            dbContextEngineMock.Setup(e => e.DbContextType)
+                .Returns(typeof(FakeDbContext));
+            dbContextEngineMock.Setup(e => e.DiscriminatorRegistry)
+                .Returns(new Mock<IDiscriminatorRegistry>().Object);
+            dbContextEngineMock.Setup(e => e.Options.DbName)
+                .Returns("fakeDb");
+            dbContextEngineMock.Setup(e => e.Options.ModelMapVersion)
+                .Returns(new ModelMapVersionOptions());
+            dbContextEngineMock.Setup(e => e.ProxyGenerator.IsProxyType(It.IsAny<Type>()))
+                .Returns(true);
+            dbContextEngineMock.Setup(e => e.ProxyGenerator.PurgeProxyType(It.IsAny<Type>()))
+                .Returns<Type>(t => t);
+            dbContextEngineMock.Setup(e => e.SerializerRegistry)
+                .Returns(new BsonSerializerRegistry());
+
+            mapRegistry.Initialize(dbContextEngineMock.Object, new Mock<ILogger>().Object);
+        }
+
+        // Tests.
+        [Fact]
+        public void FreezeFailsWithDuplicateActiveAndSecondarySchemaIdsAcrossModelMaps()
+        {
+            // Setup.
+            mapRegistry.AddModelMap<FirstModel>("first")
+                .AddSecondarySchema("shared");
+            mapRegistry.AddModelMap<SecondModel>("shared");
+
+            // Action.
+            var exception = Assert.Throws<MongodmDuplicateSchemaIdException>(() => mapRegistry.Freeze());
+
+            // Assert.
+            Assert.Contains("shared", exception.Message, StringComparison.Ordinal);
+            Assert.Contains(nameof(FirstModel), exception.Message, StringComparison.Ordinal);
+            Assert.Contains(nameof(SecondModel), exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void FreezeFailsWithDuplicateActiveSchemaIdsAcrossModelMaps()
+        {
+            // Setup.
+            mapRegistry.AddModelMap<FirstModel>("v1");
+            mapRegistry.AddModelMap<SecondModel>("v1");
+
+            // Action.
+            var exception = Assert.Throws<MongodmDuplicateSchemaIdException>(() => mapRegistry.Freeze());
+
+            // Assert.
+            Assert.Contains("v1", exception.Message, StringComparison.Ordinal);
+            Assert.Contains(nameof(FirstModel), exception.Message, StringComparison.Ordinal);
+            Assert.Contains(nameof(SecondModel), exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void FreezeFailsWithDuplicateSchemaIdsInSameModelMap()
+        {
+            // Setup.
+            mapRegistry.AddModelMap<FirstModel>("v1")
+                .AddSecondarySchema("v1");
+
+            // Action.
+            var exception = Assert.Throws<MongodmDuplicateSchemaIdException>(() => mapRegistry.Freeze());
+
+            // Assert.
+            Assert.Contains("v1", exception.Message, StringComparison.Ordinal);
+            Assert.Contains(nameof(FirstModel), exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void FreezeFailsWithReservedFallbackSchemaId()
+        {
+            // Setup.
+            mapRegistry.AddModelMap<FirstModel>("v1")
+                .AddSecondarySchema(ModelMapSchema.FallbackId);
+
+            // Action.
+            var exception = Assert.Throws<MongodmDuplicateSchemaIdException>(() => mapRegistry.Freeze());
+
+            // Assert.
+            Assert.Contains(ModelMapSchema.FallbackId, exception.Message, StringComparison.Ordinal);
+            Assert.Contains(nameof(FirstModel), exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void FreezeSucceedsWithFallbackSchemasOnDifferentModelMaps()
+        {
+            // Setup.
+            mapRegistry.AddModelMap<FirstModel>("first")
+                .AddFallbackSchema();
+            mapRegistry.AddModelMap<SecondModel>("second")
+                .AddFallbackSchema();
+
+            // Action.
+            mapRegistry.Freeze();
+
+            // Assert.
+            Assert.True(mapRegistry.IsFrozen);
+        }
+
+        [Fact]
+        public void FreezeSucceedsWithUniqueSchemaIds()
+        {
+            // Setup.
+            mapRegistry.AddModelMap<FirstModel>("first")
+                .AddSecondarySchema("first-old");
+            mapRegistry.AddModelMap<SecondModel>("second")
+                .AddSecondarySchema("second-old");
+
+            // Action.
+            mapRegistry.Freeze();
+
+            // Assert.
+            Assert.True(mapRegistry.IsFrozen);
+            Assert.Equal("first", mapRegistry.GetActiveModelMapIdBsonElement(typeof(FirstModel)).Value.AsString);
+            Assert.Equal("second", mapRegistry.GetActiveModelMapIdBsonElement(typeof(SecondModel)).Value.AsString);
+        }
+    }
+}


### PR DESCRIPTION
Closes [MODM-72](https://etherna.atlassian.net/browse/MODM-72).

## What

Model map schema ids were unique only inside their own model map: the same id could be reused on different model types of the same db context, a source of misunderstandings. Now every duplicate fails fast at engine build with a detailed `MongodmDuplicateSchemaIdException`.

## Design

- `MapRegistry.ValidateSchemaIds()` runs as the first step of the registry freeze (invoked by `DbContextEngine` at initialization): it groups all active and secondary schemas by id across every model map and throws one exception listing each violated id with the involved model types.
- Running before `LinkBaseModelMaps`, it also catches intra-map duplicates with a clear error (previously a cryptic `ArgumentException` from the `SchemasById` dictionary build).
- The `fallback` id is a sentinel shared by all fallback schemas by design: fallback schemas are excluded from the check between themselves, but an active/secondary schema using `fallback` is now an error. The id is extracted to the `ModelMapSchema.FallbackId` constant.
- Out of scope by design: `ReferenceSerializerConfiguration` registries are separate id spaces (their summary schema ids can legitimately mirror the root ones) and stay out of the check. Documented in AGENTS.md.

AGENTS.md also gains coding style rules aligned with the sibling Etherna repos (collection expressions, AAA test comments, XML docs, `System.Threading.Lock`, `field` keyword, and others), applied to the new code.

## Tests

- New `MapRegistryTest` with 6 tests: cross-map duplicates (active/active and active/secondary), intra-map duplicate, reserved `fallback` id, plus non-regression pins (unique ids and multiple fallback schemas keep working).
- Full solution Release build green on net8/9/10 with 0 warnings; unit tests 49/49; integration tests 42/42 (they boot every db context, so they gate the new startup validation against real configurations).

[MODM-72]: https://etherna.atlassian.net/browse/MODM-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ