### PR TITLE
Clear extra elements after the post-load model fix

### DIFF
--- a/src/MongODM.Core/Serialization/Serializers/ModelMapSerializer.cs
+++ b/src/MongODM.Core/Serialization/Serializers/ModelMapSerializer.cs
@@ -235,7 +235,15 @@ namespace Etherna.MongODM.Core.Serialization.Serializers
             var model = (TModel)modelMapSchema.Serializer.Deserialize(context, args);
 
             // Fix model.
-            return (TModel)await modelMapSchema.FixDeserializedModelAsync(model).ConfigureAwait(false);
+            model = (TModel)await modelMapSchema.FixDeserializedModelAsync(model).ConfigureAwait(false);
+
+            // Clear extra elements.
+            /* The fix is the consumer of the extra data: once executed, unmapped elements
+             * would only be useless weight carried in memory by the loaded model. */
+            if (model is IModel fixedModel)
+                fixedModel.ExtraElements?.Clear();
+
+            return model;
         }
     }
 }

--- a/src/MongODM.Core/Serialization/Serializers/ReferenceSerializer.cs
+++ b/src/MongODM.Core/Serialization/Serializers/ReferenceSerializer.cs
@@ -198,6 +198,12 @@ namespace Etherna.MongODM.Core.Serialization.Serializers
                 originDbExecContextHandler?.Dispose();
             }
 
+            // Clear extra elements. They are never needed with references.
+            /* Also a recognized schema can find unmapped elements: members can be added and
+             * removed without a schema id change, so a document written when a since removed
+             * member was still serialized populates the bag of the loaded summary. */
+            model?.ExtraElements?.Clear();
+
             // Process model (if proxy).
             /* Proxy models enable different features. Anyway, if the model as not been created as a proxy
              * (for example for tests scope) these additional operations are not possible or required.

--- a/test/MongODM.Core.UnitTests/ModelMapSerializerTest.cs
+++ b/test/MongODM.Core.UnitTests/ModelMapSerializerTest.cs
@@ -167,6 +167,48 @@ namespace Etherna.MongODM.Core
             Assert.Equal(test.ExpectedModel, result, new FakeModelComparer());
         }
 
+        [Fact]
+        public void DeserializeClearsExtraElementsAfterModelFix()
+        {
+            /* MODM-3: unmapped document elements populate the extra elements bag, read by
+             * the model fix during deserialization. After the fix the bag is emptied: a
+             * loaded model doesn't carry the extra data around for its whole lifetime. */
+
+            // Setup.
+            var document = new BsonDocument(new BsonElement[]
+            {
+                new("_id", new BsonString("idVal")),
+                new("StringProp", new BsonString("ok")),
+                new("removedProp", new BsonString("extraVal"))
+            } as IEnumerable<BsonElement>);
+            var bsonReader = new BsonDocumentReader(document);
+            var classMap = new BsonClassMap<FakeModel>(cm => cm.AutoMap());
+            classMap.Freeze();
+            var serializer = new ModelMapSerializer<FakeModel>(dbContextEngineMock.Object);
+
+            //the fix reads the extra element, pinning its availability before the clear
+            string? extraValueReadByFix = null;
+            modelMapMock.Setup(s => s.ActiveSchema.Serializer)
+                .Returns(classMap.ToSerializer());
+            modelMapMock.Setup(s => s.ActiveSchema.FixDeserializedModelAsync(It.IsAny<object>()))
+                .Returns<object>(m =>
+                {
+                    extraValueReadByFix = ((FakeModel)m).ExtraElements.TryGetExtraElementValue<string>("removedProp");
+                    return Task.FromResult(m);
+                });
+
+            // Action.
+            var result = serializer.Deserialize(
+                BsonDeserializationContext.CreateRoot(bsonReader),
+                new BsonDeserializationArgs { NominalType = typeof(FakeModel) });
+
+            // Assert.
+            Assert.NotNull(result);
+            Assert.Equal("extraVal", extraValueReadByFix);
+            Assert.NotNull(result.ExtraElements);
+            Assert.Empty(result.ExtraElements);
+        }
+
         [Theory]
         [InlineData("_s")]
         [InlineData("_m")]

--- a/test/MongODM.Core.UnitTests/ReferenceSerializerTest.cs
+++ b/test/MongODM.Core.UnitTests/ReferenceSerializerTest.cs
@@ -1,0 +1,103 @@
+// Copyright 2020-present Etherna SA
+// This file is part of MongODM.
+//
+// MongODM is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with MongODM.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Etherna.MongoDB.Bson;
+using Etherna.MongoDB.Bson.IO;
+using Etherna.MongoDB.Bson.Serialization;
+using Etherna.MongODM.Core.Conventions;
+using Etherna.MongODM.Core.Domain.Models;
+using Etherna.MongODM.Core.ExecContext.AsyncLocal;
+using Etherna.MongODM.Core.Models;
+using Etherna.MongODM.Core.Options;
+using Etherna.MongODM.Core.Serialization.Mapping;
+using Etherna.MongODM.Core.Serialization.Serializers;
+using Moq;
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace Etherna.MongODM.Core
+{
+    public class ReferenceSerializerTest
+    {
+        // Fields.
+        private readonly Mock<IDbContextEngine> dbContextEngineMock = new();
+        private readonly Mock<IDiscriminatorRegistry> discriminatorRegistryMock = new();
+
+        // Constructor.
+        public ReferenceSerializerTest()
+        {
+            discriminatorRegistryMock.Setup(r => r.LookupDiscriminatorConvention(It.IsAny<Type>()))
+                .Returns(() => new HierarchicalProxyTolerantDiscriminatorConvention(dbContextEngineMock.Object, "_t"));
+
+            dbContextEngineMock.Setup(e => e.DiscriminatorRegistry)
+                .Returns(() => discriminatorRegistryMock.Object);
+            dbContextEngineMock.Setup(e => e.ExecutionContext)
+                .Returns(AsyncLocalContext.Instance);
+            dbContextEngineMock.Setup(e => e.MapRegistry)
+                .Returns(new MapRegistry());
+            dbContextEngineMock.Setup(e => e.Options.ModelMapSchemaId)
+                .Returns(new ModelMapSchemaIdOptions());
+            dbContextEngineMock.Setup(e => e.ProxyGenerator.CreateInstance(It.IsAny<Type>(), It.IsAny<object[]>()))
+                .Returns<Type, object[]>((type, arguments) => Activator.CreateInstance(
+                    type,
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                    null,
+                    arguments,
+                    null)!);
+            dbContextEngineMock.Setup(e => e.ProxyGenerator.IsProxyType(It.IsAny<Type>()))
+                .Returns(false);
+        }
+
+        // Tests.
+        [Fact]
+        public void DeserializeClearsExtraElementsOnLoadedSummary()
+        {
+            /* MODM-3: members can be removed from a reference schema without changing its id
+             * (the document model tolerates added and removed fields), so a document written
+             * when the member was still serialized resolves the schema, landing the unmapped
+             * element in the extra elements bag. The bag is emptied after the load: extra
+             * data is never needed with references. */
+
+            // Setup.
+            var serializer = new ReferenceSerializer<FakeModel, string>(dbContextEngineMock.Object, config =>
+            {
+                //the auto mapped ModelBase map carries the extra elements member, as in real configurations
+                config.AddModelMap<ModelBase>("modelBaseSchemaId");
+                config.AddModelMap<FakeEntityModelBase<string>>("baseSchemaId", mm => mm.MapIdMember(m => m.Id));
+                config.AddModelMap<FakeModel>("activeSchemaId", mm => mm.AutoMap());
+            });
+            var document = new BsonDocument
+            {
+                { "_s", "activeSchemaId" },
+                { "_id", "idVal" },
+                { "StringProp", "ok" },
+                { "removedProp", "extraVal" }
+            };
+            var bsonReader = new BsonDocumentReader(document);
+
+            // Action.
+            var result = serializer.Deserialize(
+                BsonDeserializationContext.CreateRoot(bsonReader),
+                new BsonDeserializationArgs { NominalType = typeof(FakeModel) });
+
+            // Assert.
+            Assert.Equal("idVal", result.Id);
+            Assert.Equal("ok", result.StringProp);
+            //an instantiated empty bag proves the unmapped element landed there before the clear
+            Assert.NotNull(result.ExtraElements);
+            Assert.Empty(result.ExtraElements);
+        }
+    }
+}


### PR DESCRIPTION
Closes [MODM-3](https://etherna.atlassian.net/browse/MODM-3).

## What the issue asked

Once a document is deserialized and migrated, empty the extra elements bag, so a loaded model doesn't carry around useless extra data.

## Design

The bag is emptied at the end of both load paths:

- **Root and embedded documents** — `ModelMapSerializer.DeserializeModelMapSchemaHelperAsync` clears `ExtraElements` right after `FixDeserializedModelAsync`: the fix function is the consumer of the extra data, so after it runs the unmapped elements would only be useless weight carried in memory by the loaded model. The clear covers all three schema-based deserialization paths (recognized schema id, fallback schema, active schema) and happens on the fresh instance before the identity map deduplication.
- **Reference summaries** — `ReferenceSerializer.Deserialize` clears the bag of the loaded summary right after the inner deserialization. Also a recognized reference schema can land unmapped elements there: members can be added and removed without a schema id change (document model flexibility), so a document written when a since removed member was still serialized populates the bag. The clear is uniform across every serializer resolution branch (recognized schema, custom fallback, id-only fallback).

## Scope boundaries

- The root-path `FallbackSerializer` branch (arbitrary custom serializer) is left as is: models deserialized there stay protected by the serialize-time clears.
- The serialize-time clears (`ModelMapSerializer.Serialize`, `ReferenceSerializer.Serialize`) and the extra elements exclusion from the `SaveChangesAsync` diff stay in place as the persistence-side safety net.
- Reference configurations without an extra elements member in their class map chain (no auto-mapped `ModelBase`) keep failing deserialization on unexpected elements, as the driver mandates: bag tolerance requires the member, as in the integration fixtures.

## Tests

- `DeserializeClearsExtraElementsAfterModelFix` pins the root path: the fix function still reads the extra element value during deserialization (migration keeps working), and the returned model's `ExtraElements` is empty.
- `DeserializeClearsExtraElementsOnLoadedSummary` pins the reference path: a summary document with a recognized schema id and an unmapped element deserializes with an instantiated but empty bag (the instantiation itself proves the element landed there before the clear).

Both fail on the base code with `Assert.Empty() Failure: Collection was not empty`. Full solution builds in Release with 0 warnings on every target framework; 106 core + 5 generators unit tests and 77 integration tests all green.

[MODM-3]: https://etherna.atlassian.net/browse/MODM-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ