### PR TITLE
remove morelinq dependency

### DIFF
--- a/src/MongODM.Core/MongODM.Core.csproj
+++ b/src/MongODM.Core/MongODM.Core.csproj
@@ -47,7 +47,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="morelinq" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MongODM.Core/Tasks/UpdateDocDependenciesTask.cs
+++ b/src/MongODM.Core/Tasks/UpdateDocDependenciesTask.cs
@@ -25,7 +25,6 @@ using Etherna.MongODM.Core.Repositories;
 using Etherna.MongODM.Core.Serialization.Mapping;
 using Etherna.MongODM.Core.Utility;
 using Microsoft.Extensions.Logging;
-using MoreLinq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -218,9 +217,7 @@ namespace Etherna.MongODM.Core.Tasks
                 arrayFilters.Add(new BsonDocumentArrayFilterDefinition<BsonDocument>(
                     new BsonDocument($"idfilter{string.Join(".",
                         idMemberMap.MemberMapPath
-                            .Reverse()
-                            .TakeUntil(mm => mm == lastUndefinedArrayElement.MemberMap)
-                            .Reverse() //take all final memeber maps in path until we reach the last with undefined array index
+                            .SkipWhile(mm => mm != lastUndefinedArrayElement.MemberMap) //take all final member maps in path from the last with undefined array index
                             .Select(mm =>
                             {
                                 //if is the last member map, render internal path only after the last undefined array index

--- a/test/MongODM.IntegrationTests/ModelMaps/MessageMap.cs
+++ b/test/MongODM.IntegrationTests/ModelMaps/MessageMap.cs
@@ -24,6 +24,18 @@ namespace Etherna.MongODM.IntegrationTests.ModelMaps
     {
         public void Register(IDbContextEngine dbContextEngine)
         {
+            dbContextEngine.MapRegistry.AddModelMap<Envelope>(
+                "86d458e2-e618-466f-b29c-bf04fceb5196",
+                mm =>
+                {
+                    mm.AutoMap();
+
+                    // Set members with custom serializers.
+                    mm.SetMemberSerializer(m => m.Recipients,
+                        new EnumerableSerializer<AccountBase>(
+                            AccountMap.SummaryInfoSerializer(dbContextEngine)));
+                });
+
             dbContextEngine.MapRegistry.AddModelMap<Message>(
                 "d2a3f7e1-4b8c-49a1-9f6e-3f52290ab1c4",
                 mm =>

--- a/test/MongODM.IntegrationTests/Models/Envelope.cs
+++ b/test/MongODM.IntegrationTests/Models/Envelope.cs
@@ -1,0 +1,42 @@
+// Copyright 2020-present Etherna SA
+// This file is part of MongODM.
+//
+// MongODM is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with MongODM.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+
+namespace Etherna.MongODM.IntegrationTests.Models
+{
+    /// <summary>
+    /// A value object embedded by <see cref="Message"/>, hosting account references
+    /// inside a nested document.
+    /// </summary>
+    public class Envelope
+    {
+        // Fields.
+        private List<AccountBase> _recipients = [];
+
+        // Constructors.
+        public Envelope(IEnumerable<AccountBase> recipients)
+        {
+            Recipients = recipients;
+        }
+        protected Envelope() { }
+
+        // Properties.
+        public virtual IEnumerable<AccountBase> Recipients
+        {
+            get => _recipients;
+            protected set => _recipients = [.. value ?? []];
+        }
+    }
+}

--- a/test/MongODM.IntegrationTests/Models/Message.cs
+++ b/test/MongODM.IntegrationTests/Models/Message.cs
@@ -36,6 +36,7 @@ namespace Etherna.MongODM.IntegrationTests.Models
         // Properties.
         public virtual AccountBase Author { get; protected set; }
         public virtual AccountBase Editor { get; set; }
+        public virtual Envelope? Envelope { get; set; }
         public virtual string Text { get; set; }
         public virtual IEnumerable<AccountBase> Watchers
         {

--- a/test/MongODM.IntegrationTests/UpdateDocDependenciesTests.cs
+++ b/test/MongODM.IntegrationTests/UpdateDocDependenciesTests.cs
@@ -454,6 +454,50 @@ namespace Etherna.MongODM.IntegrationTests
             Assert.Equal("bob", rawBob["Username"].AsString);
         }
 
+        [Fact]
+        public async Task UpdatesSummariesHostedByArraysOfEmbeddedDocuments()
+        {
+            /* Summaries hosted by a collection member of an embedded document update
+             * through the nested element path (Envelope.Recipients.$[idfilter]), with
+             * the array filter addressing the id relatively to the array member, not
+             * from the document root. The type change of the referenced account makes
+             * the rewrite observable on the item discriminator. */
+
+            // Setup.
+            using var contextHandler = AsyncLocalContext.Instance.InitAsyncLocalContext();
+            fixture.TaskRunner.ClearPending();
+
+            var alice = new Web2Account("alice");
+            await dbContext.Accounts.CreateAsync(alice);
+            var bob = new Web2Account("bob");
+            await dbContext.Accounts.CreateAsync(bob);
+
+            var message = new Message("hello", alice, bob)
+            {
+                Envelope = new Envelope([alice, bob])
+            };
+            await dbContext.Messages.CreateAsync(message);
+
+            // Action: evolve alice into a web3 account, and execute the enqueued task.
+            var web3Alice = new Web3Account(alice, "0x0123456789");
+            await dbContext.Accounts.ReplaceAsync(web3Alice);
+            await fixture.TaskRunner.ExecutePendingAsync(fixture.ServiceProvider);
+
+            // Assert.
+            var messagesCollection = dbContext.Engine.Database.GetCollection<BsonDocument>("messages");
+            var rawRecipients = (await messagesCollection.Find(IdFilter(message.Id)).SingleAsync())["Envelope"]["Recipients"].AsBsonArray;
+
+            var rawAlice = rawRecipients.Single(r => r["_id"] == ObjectId.Parse(alice.Id)).AsBsonDocument;
+            Assert.Equal("Web3Account", rawAlice["_t"].AsString);
+            Assert.Equal("06d4e4c1-1e57-4bd0-a071-90fe7d3dbc2a", rawAlice["_s"].AsString); //summary schema of the new type
+            Assert.Equal("alice", rawAlice["Username"].AsString);
+
+            var rawBob = rawRecipients.Single(r => r["_id"] == ObjectId.Parse(bob.Id)).AsBsonDocument;
+            Assert.Equal("Web2Account", rawBob["_t"].AsString);
+            Assert.Equal("f5825985-4d3a-43e0-a15a-e6f504c34e07", rawBob["_s"].AsString); //untouched original summary
+            Assert.Equal("bob", rawBob["Username"].AsString);
+        }
+
         // Helpers.
         private async Task<(long FindAndModify, long Update)> GetServerCommandCountersAsync()
         {


### PR DESCRIPTION
Closes [MODM-196](https://etherna.atlassian.net/browse/MODM-196).

## What

Removes the `morelinq` package dependency from `Etherna.MongODM.Core`. The only usage in the whole solution was the `TakeUntil` operator in `UpdateDocDependenciesTask`, inside the construction of the `idfilter` array filter path.

## Design

The original expression took the suffix of `MemberMapPath` starting at the member map hosting the last undefined array index (inclusive), via `Reverse().TakeUntil(...).Reverse()`. It is replaced with the equivalent standard LINQ `SkipWhile(mm => mm != target)`: `MemberMapPath` is the ancestors chain built through `ParentMemberMap` links, so each member map occurs exactly once in its own path and the target is always present (it belongs to the parent's path, a prefix of the id member's path). The rewrite also drops the two `Reverse()` passes.

## Tests

The pre-existing array propagation test (`UpdatesOnlyTheMatchingArrayItems`) hosts the references on a root-level member, where the suffix computation is a no-op, so it could not pin the suffix semantics. This change adds the missing nested shape to the integration models — an `Envelope` value object embedded by `Message`, hosting account references in a collection — and a new test (`UpdatesSummariesHostedByArraysOfEmbeddedDocuments`) pinning the propagation through `Envelope.Recipients.$[idfilter]`. Verified discriminating: with the suffix drop removed, the server rejects the malformed array filter and the test fails.

Full solution builds in Release on every target framework with 0 warnings; all tests green (141 unit + 5 generator + 99 integration against a real mongod).

[MODM-196]: https://etherna.atlassian.net/browse/MODM-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ