### PR TITLE
isolate gitversion output file per build instance

### DIFF
--- a/.github/workflows/myget-unstable-deploy.yml
+++ b/.github/workflows/myget-unstable-deploy.yml
@@ -41,10 +41,10 @@ jobs:
         run: dotnet build --configuration Release
 
       - name: Run unit tests
-        run: dotnet test --configuration Release
-      
+        run: dotnet test --configuration Release --no-build
+
       - name: Generate nuget package
-        run: dotnet pack --configuration Release -o nupkg
+        run: dotnet pack --configuration Release --no-build -o nupkg
 
       - name: Push packages
         run: dotnet nuget push './nupkg/*.nupkg' --api-key ${{secrets.MYGET_APIKEY}} --source https://www.myget.org/F/etherna/api/v3/index.json

--- a/.github/workflows/nuget-stable-deploy.yml
+++ b/.github/workflows/nuget-stable-deploy.yml
@@ -39,10 +39,10 @@ jobs:
         run: dotnet build --configuration Release
 
       - name: Run unit tests
-        run: dotnet test --configuration Release
+        run: dotnet test --configuration Release --no-build
 
       - name: Generate nuget package
-        run: dotnet pack --configuration Release -o nupkg
+        run: dotnet pack --configuration Release --no-build -o nupkg
 
       - name: Push packages
         run: dotnet nuget push './nupkg/*.nupkg' --api-key ${{secrets.NUGET_KEY}} --source https://api.nuget.org/v3/index.json

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,5 +2,12 @@
   <PropertyGroup>
     <!-- Audit only direct dependencies, not transitive ones -->
     <NuGetAuditMode>direct</NuGetAuditMode>
+
+    <!-- GitVersion.MsBuild writes and reads its version file at a per project path shared by every
+         build instance of a multi targeting project: parallel target framework inner builds race on
+         it, and a reader can find the file truncated by a concurrent writer. One file per instance.
+         The override must stay in props (the package props freeze the tool arguments with this value)
+         and can't use $(BaseIntermediateOutputPath), still undefined when this file imports. -->
+    <GitVersionOutputFile>$(MSBuildProjectDirectory)/obj/gitversion.$(TargetFramework).json</GitVersionOutputFile>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes [MODM-214](https://etherna.atlassian.net/browse/MODM-214): CI builds fail intermittently with `GitVersion.MsBuild.targets(121,9): error : JsonException: The input does not contain any JSON tokens`.

## Root cause

GitVersion.MsBuild defines `GitVersionOutputFile` as `obj/gitversion.json`, a per project path shared by every build instance of a multi targeting project. Each instance (outer build plus one inner build per target framework) reruns `RunGitVersion`, rewriting that file, and then reads it back in the `GetVersion`/`GenerateGitVersionInformation` tasks. Inner builds run in parallel, so a reader can find the file while a concurrent writer is truncating it: the file exists but is empty, and the JSON deserialization throws (the Polly retry inside GitVersion covers IO errors, not an existing-but-empty file).

## Fix

`Directory.Build.props` overrides `GitVersionOutputFile` to `obj/gitversion.$(TargetFramework).json`: one file per build instance, no shared state. Two constraints, verified with `msbuild -getProperty`, shaped the override:

- It must live in **props**, not `Directory.Build.targets`: the package props freeze `GitVersion_ToolArgments` (the writer's `-outputfile` argument) by expanding `$(GitVersionOutputFile)` at their own evaluation time, so a late override would split the writer path from the reader path.
- It can't use `$(BaseIntermediateOutputPath)` as the issue proposed: that property is still undefined when `Directory.Build.props` imports (Microsoft.Common.props defaults it afterwards), which would drop the file into the project root. The override uses `$(MSBuildProjectDirectory)/obj/` instead.

Both workflows also gain `--no-build` on the `dotnet test` and `dotnet pack` steps: the preceding step already built Release, so this removes two full rebuilds and their redundant GitVersion executions per project.

## Validation

Replicating the CI steps locally:

- `dotnet build MongODM.sln -c Release`: green, 0 warnings.
- Version files all land inside `obj/` (`gitversion.net8.0.json`/`net9.0`/`net10.0`, plus `gitversion..json` for the outer instance during pack), none stray.
- `dotnet test -c Release --no-build`: 163 unit + 5 generator + 114 integration tests passed.
- `dotnet pack -c Release --no-build`: all 5 packages produced with the correct GitVersion computed version.

The race itself is intermittent and not deterministically reproducible in a test; the proof is on the mechanism — before the fix all instances of a project shared `obj/gitversion.json` (the package default, whose targets line 121 is exactly the failing task), after it each instance owns its file, with writer and readers agreeing on the path.

[MODM-214]: https://etherna.atlassian.net/browse/MODM-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ