### PR TITLE
Dispose ambient execution context handler on collection access failures

### DIFF
--- a/src/MongODM.Core/Repositories/Repository.cs
+++ b/src/MongODM.Core/Repositories/Repository.cs
@@ -93,13 +93,14 @@ namespace Etherna.MongODM.Core.Repositories
             _collection ??= DbContext.Engine.GetMongoCollection<TModel>(options.Name, isReadOnly: options.IsReadOnly);
 
             // Invoke func into optional implicit execution context.
-            DbExecutionContextHandler? dbExecContextHandler = null;
-            if (handleImplicitDbExecutionContext)
-                dbExecContextHandler = new DbExecutionContextHandler(DbContext, this);
+            /* The handler disposal must run also when func throws: a handler leaked in the
+             * flow items would become the ambient one again once the handlers above it
+             * complete, resolving the wrong db context and repository for the rest of the flow. */
+            using var dbExecContextHandler = handleImplicitDbExecutionContext
+                ? new DbExecutionContextHandler(DbContext, this)
+                : null;
 
             var result = await func(_collection).ConfigureAwait(false);
-
-            dbExecContextHandler?.Dispose();
 
             logger.RepositoryAccessedCollection(Name, DbContext.Engine.Options.DbName);
 
@@ -301,15 +302,25 @@ namespace Etherna.MongODM.Core.Repositories
             // Create an explicit db execution context. It needs to survive until cursor is alive.
             var dbExecContextHandler = new DbExecutionContextHandler(DbContext, this);
 
-            return await AccessToCollectionAsync(async collection =>
+            try
             {
-                var resultCursor = await collection.FindAsync(filter, options, cancellationToken).ConfigureAwait(false);
-                var wrappedCursor = new AsyncCursorWrapper<TProjection>(resultCursor, dbExecContextHandler);
+                return await AccessToCollectionAsync(async collection =>
+                {
+                    var resultCursor = await collection.FindAsync(filter, options, cancellationToken).ConfigureAwait(false);
+                    var wrappedCursor = new AsyncCursorWrapper<TProjection>(resultCursor, dbExecContextHandler);
 
-                logger.RepositoryQueriedCollection(Name, DbContext.Engine.Options.DbName);
+                    logger.RepositoryQueriedCollection(Name, DbContext.Engine.Options.DbName);
 
-                return wrappedCursor;
-            }, false).ConfigureAwait(false);
+                    return wrappedCursor;
+                }, false).ConfigureAwait(false);
+            }
+            catch
+            {
+                /* The cursor wrapper owns the handler and disposes it with the cursor:
+                 * when the access fails before producing the wrapper, release it here. */
+                dbExecContextHandler.Dispose();
+                throw;
+            }
         }
 
         public async Task<object> FindOneAsync(object id, CancellationToken cancellationToken = default) =>

--- a/test/MongODM.Core.UnitTests/Repositories/RepositoryTest.cs
+++ b/test/MongODM.Core.UnitTests/Repositories/RepositoryTest.cs
@@ -18,11 +18,13 @@ using Etherna.MongODM.Core.ExecContext;
 using Etherna.MongODM.Core.Models;
 using Etherna.MongODM.Core.Options;
 using Etherna.MongODM.Core.Serialization.Mapping;
+using Etherna.MongODM.Core.Utility;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -34,6 +36,7 @@ namespace Etherna.MongODM.Core.Repositories
         private readonly Mock<IMongoCollection<FakeModel>> collectionMock = new();
         private readonly Mock<IDbContext> dbContextMock = new();
         private readonly Mock<IDbContextEngine> engineMock = new();
+        private readonly Dictionary<object, object?> executionContextItems = [];
         private readonly Mock<IExecutionContext> executionContextMock = new();
         private readonly Mock<IMapRegistry> mapRegistryMock = new();
         private readonly Mock<IModelMap> modelMapMock = new();
@@ -69,7 +72,7 @@ namespace Etherna.MongODM.Core.Repositories
             collectionMock.Setup(c => c.Settings)
                 .Returns(new MongoCollectionSettings { SerializerRegistry = new BsonSerializerRegistry() });
 
-            executionContextMock.Setup(c => c.Items).Returns(new Dictionary<object, object?>());
+            executionContextMock.Setup(c => c.Items).Returns(executionContextItems);
             optionsMock.Setup(o => o.DbName).Returns("test-db");
             engineMock.Setup(e => e.ExecutionContext).Returns(executionContextMock.Object);
             engineMock.Setup(e => e.MapRegistry).Returns(mapRegistryMock.Object);
@@ -80,6 +83,37 @@ namespace Etherna.MongODM.Core.Repositories
         }
 
         // Tests.
+        [Fact]
+        public async Task AccessToCollectionDisposesTheAmbientHandlerWhenTheAccessedOperationSucceeds()
+        {
+            // Setup.
+            var repository = BuildRepository();
+
+            // Action.
+            await repository.AccessToCollectionAsync(_ => Task.FromResult(0));
+
+            // Assert.
+            Assert.Empty(GetAmbientDbExecContextHandlers());
+        }
+
+        [Fact]
+        public async Task AccessToCollectionDisposesTheAmbientHandlerWhenTheAccessedOperationThrows()
+        {
+            /* A leaked handler would stay registered in the flow items and become the
+             * ambient one again once the handlers above it complete, resolving the wrong
+             * db context, repository and serializer registry for the rest of the flow. */
+
+            // Setup.
+            var repository = BuildRepository();
+
+            // Action.
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                repository.AccessToCollectionAsync<int>(_ => throw new InvalidOperationException()));
+
+            // Assert.
+            Assert.Empty(GetAmbientDbExecContextHandlers());
+        }
+
         [Fact]
         public async Task DefinedIndexesBuildAnAutomaticIndexForEachReferenceIdPath()
         {
@@ -169,6 +203,72 @@ namespace Etherna.MongODM.Core.Repositories
                 indexes.Select(i => i.Options.Name));
         }
 
+        [Fact]
+        public async Task FindDisposesTheAmbientHandlerWhenTheCollectionAccessThrows()
+        {
+            // Setup.
+            collectionMock.Setup(c => c.FindAsync(
+                    It.IsAny<FilterDefinition<FakeModel>>(),
+                    It.IsAny<FindOptions<FakeModel, FakeModel>>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException());
+            var repository = BuildRepository();
+
+            // Action.
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                repository.FindAsync<FakeModel>(Builders<FakeModel>.Filter.Empty));
+
+            // Assert.
+            Assert.Empty(GetAmbientDbExecContextHandlers());
+        }
+
+        [Fact]
+        public async Task FindKeepsTheAmbientHandlerUntilTheCursorIsDisposed()
+        {
+            // Setup.
+            collectionMock.Setup(c => c.FindAsync(
+                    It.IsAny<FilterDefinition<FakeModel>>(),
+                    It.IsAny<FindOptions<FakeModel, FakeModel>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Mock<IAsyncCursor<FakeModel>>().Object);
+            var repository = BuildRepository();
+
+            // Action.
+            var cursor = await repository.FindAsync<FakeModel>(Builders<FakeModel>.Filter.Empty);
+
+            // Assert.
+            //the handler serves the cursor consumption, and releases with its disposal
+            Assert.Single(GetAmbientDbExecContextHandlers());
+            cursor.Dispose();
+            Assert.Empty(GetAmbientDbExecContextHandlers());
+        }
+
+        [Fact]
+        public async Task TryFindOneDisposesTheAmbientHandlerOnAMissingId()
+        {
+            /* A miss is ordinary control flow: the collection access throws
+             * MongodmEntityNotFoundException, and TryFindOneAsync turns it into a null
+             * result. The ambient handler must release also on this path. */
+
+            // Setup.
+            var cursorMock = new Mock<IAsyncCursor<FakeModel>>();
+            cursorMock.Setup(c => c.MoveNextAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+            collectionMock.Setup(c => c.FindAsync(
+                    It.IsAny<FilterDefinition<FakeModel>>(),
+                    It.IsAny<FindOptions<FakeModel, FakeModel>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(cursorMock.Object);
+            var repository = BuildRepository();
+
+            // Action.
+            var result = await repository.TryFindOneAsync("missingId");
+
+            // Assert.
+            Assert.Null(result);
+            Assert.Empty(GetAmbientDbExecContextHandlers());
+        }
+
         // Helpers.
         private Repository<FakeModel, string> BuildRepository(
             params (IndexKeysDefinition<FakeModel> keys, CreateIndexOptions<FakeModel> options)[] indexBuilders)
@@ -178,6 +278,11 @@ namespace Etherna.MongODM.Core.Repositories
             repository.Initialize(dbContextMock.Object, new Mock<ILogger>().Object);
             return repository;
         }
+
+        private IEnumerable<DbExecutionContextHandler> GetAmbientDbExecContextHandlers() =>
+            executionContextItems.Values
+                .OfType<IEnumerable<DbExecutionContextHandler>>()
+                .SelectMany(handlers => handlers);
 
         private static IMemberMap ReferenceIdMemberMap(params BsonMemberMap[] elementPath)
         {


### PR DESCRIPTION
## Issue

[MODM-217](https://etherna.atlassian.net/browse/MODM-217) — the ambient `DbExecutionContextHandler` leaked on the exception path of collection access: it was created before the guarded operation and disposed only after it returned, so any failure left the handler registered in the flow's ambient list. As the issue's comment notes, the leak is not limited to database errors: an ordinary `TryFindOneAsync` miss throws too.

## Design

- `AccessToCollectionAsync<TResult>` replaces the manual create/dispose with a conditional `using var` (`handleImplicitDbExecutionContext ? new DbExecutionContextHandler(DbContext, this) : null`), the pattern every other handler creation in the library follows. Success-path semantics are unchanged.
- `FindAsync` is the case that cannot use `using`: the handler must survive with the cursor, owned by `AsyncCursorWrapper`. It keeps creating the handler before the guarded access and wraps that access in a `try`/`catch` + `throw;`, disposing the handler only when the wrapper is not produced — the bare rethrowing `catch` mirrors the existing shape in `DbContext.ExecuteInTransactionAsync`.

## Tests

`RepositoryTest` asserts the ambient handler list through the `IExecutionContext.Items` dictionary the test itself supplies, so no private handler key is hardcoded:

- `AccessToCollectionDisposesTheAmbientHandlerWhenTheAccessedOperationThrows` (regression)
- `FindDisposesTheAmbientHandlerWhenTheCollectionAccessThrows` (regression)
- `TryFindOneDisposesTheAmbientHandlerOnAMissingId` (regression, the routine miss path)
- `AccessToCollectionDisposesTheAmbientHandlerWhenTheAccessedOperationSucceeds` (pin)
- `FindKeepsTheAmbientHandlerUntilTheCursorIsDisposed` (pin: the handler must still survive a live cursor)

Build Release green with 0 warnings on every target framework; full suite 298/298 green on the current dev base. Regression proven: on the base sources the three regression tests fail with the leaked `DbExecutionContextHandler` still in the ambient list, while both pins stay green.

## Scope

Only the disposal paths. The sibling execution-context issues (MODM-218 parallel-flow safety, MODM-234 exclusive access scoping) are addressed on their own branches; `DbExecutionContextHandler.Dispose` is left untouched.

[MODM-217]: https://etherna.atlassian.net/browse/MODM-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ