### PR TITLE
Hand over the flows of the concurrency tests with signals

### DIFF
--- a/test/MongODM.Core.UnitTests/DbContextTest.cs
+++ b/test/MongODM.Core.UnitTests/DbContextTest.cs
@@ -36,6 +36,8 @@ namespace Etherna.MongODM.Core
     public class DbContextTest : IDisposable
     {
         // Consts.
+        //bounds the handovers between the flows of a test: a missing signal must fail it, not hang it
+        private static readonly TimeSpan HandoverBound = TimeSpan.FromSeconds(30);
         //bounds the seeding lock waits: a regressed wait resolution must fail the tests, not hang them
         private static readonly TimeSpan SeedingWaitBound = TimeSpan.FromSeconds(30);
 
@@ -434,54 +436,63 @@ namespace Etherna.MongODM.Core
         [InlineData(true)]
         public async Task CanRunExclusiveAccess(bool lockOnRead)
         {
+            /* The two flows hand over with signals, and not with delays: an exclusive window
+             * that opens late, on a loaded machine, would otherwise still be open when the
+             * other flow expects it closed. */
             var fakeModel = new FakeModel { Id = "id" };
+            var deniedAccessObserved = new TaskCompletionSource();
+            var exclusiveAccessEnded = new TaskCompletionSource();
+            var exclusiveAccessStarted = new TaskCompletionSource();
+            var freeAccessObserved = new TaskCompletionSource();
 
             async Task Process1()
             {
                 using var contextHandler = AsyncLocalContext.Instance.InitAsyncLocalContext();
-                
+
                 //succeeds without exclusive access
                 await dbContext.FakeModels.CreateAsync(fakeModel);
                 await dbContext.FakeModels.FindOneAsync("test");
+                freeAccessObserved.SetResult();
 
-                await Task.Delay(500);
-                
                 //fails with exclusive access without an allowed area. Can read if not locked
+                await exclusiveAccessStarted.Task.WaitAsync(HandoverBound);
                 await Assert.ThrowsAsync<UnauthorizedAccessException>(() => dbContext.FakeModels.CreateAsync(fakeModel));
                 if (lockOnRead)
                     await Assert.ThrowsAsync<UnauthorizedAccessException>(() => dbContext.FakeModels.FindOneAsync("test"));
                 else
                     await dbContext.FakeModels.FindOneAsync("test");
-                
-                await Task.Delay(500);
-                
+                deniedAccessObserved.SetResult();
+
                 //succeeds without exclusive access
+                await exclusiveAccessEnded.Task.WaitAsync(HandoverBound);
                 await dbContext.FakeModels.CreateAsync(fakeModel);
                 await dbContext.FakeModels.FindOneAsync("test");
             }
             async Task Process2()
             {
                 using var contextHandler = AsyncLocalContext.Instance.InitAsyncLocalContext();
-                
+
                 //succeeds without exclusive access
                 await dbContext.FakeModels.CreateAsync(fakeModel);
                 await dbContext.FakeModels.FindOneAsync("test");
-                
-                await Task.Delay(250);
-                
-                //run exclusive access with allowed area
+
+                //run exclusive access with allowed area, entered after the other flow accessed freely
+                await freeAccessObserved.Task.WaitAsync(HandoverBound);
                 var result = await dbContext.Engine.RunWithExclusiveAccessAsync(async () =>
                 {
                     //succeed with exclusive access in allowed area
                     await dbContext.FakeModels.CreateAsync(fakeModel);
                     await dbContext.FakeModels.FindOneAsync("test");
-                    
-                    await Task.Delay(500);
-                    
+                    exclusiveAccessStarted.SetResult();
+
+                    //hold the window open until the other flow observed its denial
+                    await deniedAccessObserved.Task.WaitAsync(HandoverBound);
+
                     return 42;
                 }, lockOnRead);
                 Assert.Equal(42, result);
-                
+                exclusiveAccessEnded.SetResult();
+
                 //succeeds without exclusive access
                 await dbContext.FakeModels.CreateAsync(fakeModel);
                 await dbContext.FakeModels.FindOneAsync("test");

--- a/test/MongODM.Core.UnitTests/Utility/DbContextLockTest.cs
+++ b/test/MongODM.Core.UnitTests/Utility/DbContextLockTest.cs
@@ -46,6 +46,10 @@ namespace Etherna.MongODM.Core.Utility
         /* A lease short enough to observe its background renewals inside a test: they run at
          * a fifth of the lease duration carried by the lease document. */
         private static readonly TimeSpan FastRenewalLeaseDuration = TimeSpan.FromMilliseconds(250);
+        /* A lease long enough for a renewal to recover from a failed one inside it, on a
+         * loaded machine: a recovery landing past the lease duration would lose the lease,
+         * which is the behavior of its own test. */
+        private static readonly TimeSpan RecoverableRenewalLeaseDuration = TimeSpan.FromSeconds(2.5);
         private const string LockId = "FakeDbContext";
         private static readonly TimeSpan RenewalsWaitBound = TimeSpan.FromSeconds(10);
 
@@ -355,8 +359,8 @@ namespace Etherna.MongODM.Core.Utility
              * still alive until its expiration, and the next renewals keep it so. */
 
             // Setup.
-            //a lease claimed for a short duration: its renewals run at a fifth of it
-            SetupLeaseStamp(NewLeaseDocument(FastRenewalLeaseDuration));
+            //renewals run at a fifth of the lease: the recovery lands well inside it
+            SetupLeaseStamp(NewLeaseDocument(RecoverableRenewalLeaseDuration));
 
             var renewalsSignal = new TaskCompletionSource();
             var updates = 0;
@@ -373,7 +377,8 @@ namespace Etherna.MongODM.Core.Utility
                         return Task.FromException<UpdateResult>(new MongoConnectionException(
                             NewConnectionId(), "The server is unreachable"));
 
-                    if (update >= 4)
+                    //the resume renewed, the second failed, this one recovers
+                    if (update >= 3)
                         renewalsSignal.TrySetResult();
                     return Task.FromResult<UpdateResult>(new UpdateResult.Acknowledged(1, 1, null));
                 });


### PR DESCRIPTION
## Issue

[MODM-247](https://etherna.atlassian.net/browse/MODM-247) — the CI build fails on `DbContextTest.CanRunExclusiveAccess` with `UnauthorizedAccessException : Write access is not allowed`, on a write the test expects to be allowed.

Two tests coordinate their flows with `Task.Delay` instead of signals, and their margins don't survive a loaded machine. The failure doesn't appear on a developer machine and appears every time under the runner's profile — the four test projects in parallel on two vCPUs: pinning the CI command to two cores (`taskset -c 0,1 dotnet test MongODM.sln -c Release --no-build`) fails 3 runs out of 3.

## What was wrong

`CanRunExclusiveAccess` choreographs two flows with delays: the second opens the exclusive window after 250 ms and holds it 500 ms, while the first asserts a denial at 500 ms and an allowed write at 1000 ms. Between the window closing (about 750 ms) and that last write there are 250 ms, so a quarter of a second of scheduling latency leaves the window open when the first flow expects it closed. The test predates the 0.25.0 bugfix line — at 1082c3e the same profile already fails 1 run out of 3 — and the suite growing from about 280 to about 400 tests turned an occasional failure into a certain one.

`DbContextLockTest.LeaseSurvivesATransientRenewalFailure` pins that a renewal failing inside the lease duration doesn't end the lease. With a 250 ms lease the recovering renewal has to land within 250 ms of the last successful one; under the same load it lands later, the lease is correctly abandoned by its own liveness rule, and the test waits for a signal that never comes.

## Fix

`CanRunExclusiveAccess` hands over with `TaskCompletionSource` signals: the second flow opens the window only after the first has done its free accesses, holds it open until the first has observed its denial, and the first retries its write only once the window has actually closed. No step depends on how fast the machine is.

`LeaseSurvivesATransientRenewalFailure` gets a lease duration whose margin survives a loaded machine — the recovery lands about a second after the last success, inside a two and a half second lease — and signals on the recovering renewal instead of the one after it.

Every wait is bounded, so a missing signal fails the test instead of hanging the suite.

## Verification

Build Release green with 0 warnings on every target framework; full suite **407 passed**. Under the two-core CI profile: 4 runs out of 4 green, against 3 out of 3 failing before the fix.

[MODM-247]: https://etherna.atlassian.net/browse/MODM-247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ